### PR TITLE
chore(review): address CodeRabbit findings on vm-drop-selection

### DIFF
--- a/docs/adr/ADR-021-vm-exclusion-rules-persistence.md
+++ b/docs/adr/ADR-021-vm-exclusion-rules-persistence.md
@@ -1,20 +1,28 @@
 # ADR-021: VM exclusion rules persist, raw rows do not
 
 ## Status
+
 Accepted — 2026-04-17
 
 ## Context
+
 Issue #13 requires letting users exclude individual VMs from the sizing
 calculation. Possible approaches ranged from storing filtered aggregates
 (no round-trip) to persisting every VM row (no URL-hash support at scale).
 
 ## Decision
+
 Persist only the `ExclusionRules` object (globs + exact names + flags +
 manual overrides) in localStorage, JSON exports, and URL hashes.
 Raw per-VM rows stay session-only on `useImportStore`, discarded on
 reload. Post-reload the rules UI is read-only; users re-import to edit.
 
+Manual override entries (`manuallyExcluded`, `manuallyIncluded`) are
+stored as `${scopeKey}::${name}` composite keys so that duplicate VM
+names across clusters can be targeted individually.
+
 ## Rationale
+
 - URL hashes have an ~8 KB ceiling; VM rows at enterprise scale exceed it
   by orders of magnitude.
 - Rules express intent and are forward-compatible with re-imports of a
@@ -24,6 +32,7 @@ reload. Post-reload the rules UI is read-only; users re-import to edit.
   reload still reproduces the sizing numbers.
 
 ## Consequences
+
 - (+) Small persisted payload; scales to clusters of any size.
 - (+) Rules can be shared and re-applied to a newer source file.
 - (-) Users who reload mid-session cannot tweak per-row overrides
@@ -32,6 +41,11 @@ reload. Post-reload the rules UI is read-only; users re-import to edit.
       input; URL hash encoder truncates them when over budget.
 
 ## Related decisions
+
 - Glob-over-regex for `namePattern` — ReDoS-safe by construction.
 - JSON schema v2 adds an optional `exclusions` block; v1 files migrate
   in by injecting `EMPTY_RULES`.
+- `useExclusionsStore` persist version bumped from 1 → 2 when manual
+  overrides changed from bare names to composite keys; v1 migrations
+  drop the manual lists because bare names cannot be remapped to scopes
+  without the original import context.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -309,7 +309,7 @@ All export functions receive cluster, scenarios, and results as parameters. CSV 
 
 ## 12. Per-VM Exclusions (v2.7)
 
-**Pure engine** — `src/lib/utils/import/exclusions.ts` exports `compileNamePattern` (glob→regex, ReDoS-safe), `isExcluded` (short-circuits on overrides → power state → exact name → glob), and `applyExclusions(grouped, rules)` returning `{ filtered, stats }`. All functions are pure; no store access.
+**Pure engine** — `src/lib/utils/import/exclusions.ts` exports `compileNamePattern` (glob→regex, ReDoS-safe), `isExcluded` (short-circuits on manual overrides → name pattern → exact names → power state), and `applyExclusions(grouped, rules)` returning `{ filteredByScope, stats }`. Manual override lists hold `${scopeKey}::${name}` composite keys so duplicate VM names across clusters can be targeted individually. All functions are pure; no store access.
 
 **Aggregation** — `aggregateVmRows` recomputes `totalVcpus`, `totalVms`, `totalDiskGb`, and `avgRamPerVmGb` from the kept subset. `recomputeCluster` in `useImportStore` re-aggregates on rules changes while preserving ESX-derived fields (pCores, server config, utilization percentages) that do not belong to VM rows.
 

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -432,8 +432,9 @@ Used for persistence and shareable URLs. Defined in `src/lib/utils/persistence.t
 
 ```json
 {
-  "version": "2",
-  "cluster": { ... },
+  "schemaVersion": "2",
+  "generatedAt": "2026-04-18T10:00:00.000Z",
+  "currentCluster": { ... },
   "scenarios": [ ... ],
   "exclusions": {
     "namePattern": "test-*",
@@ -446,7 +447,8 @@ Used for persistence and shareable URLs. Defined in `src/lib/utils/persistence.t
 ```
 
 - `exclusions` is optional. V1 files (no `exclusions` block) load with `EMPTY_RULES` injected — fully backward-compatible.
-- Schema version bumped from `"1.1"` to `"2"` when exclusions are present.
+- `schemaVersion` bumps from `"1.1"` to `"2"` whenever exclusions are emitted. Earlier `schemaVersion: "1.1"` examples in this document describe the legacy format and are kept for reference.
+- `manuallyExcluded` / `manuallyIncluded` entries are stored as `${scopeKey}::${vmName}` composite keys so that duplicate VM names across scopes can be targeted individually.
 
 ### URL hash v2 with truncation
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -292,4 +292,4 @@ There is no explicit cleanup. Zustand stores persist for the lifetime of the pag
 
 ### Recompute Hook
 
-`useRecomputeCluster()` subscribes to both `useExclusionsStore.rules` and `useImportStore.vmRowsByScope`. On change it calls `applyExclusions` + `aggregateVmRows` and writes the kept aggregates back into `useClusterStore`, preserving ESX-derived fields (server config, utilization %).
+`useRecomputeCluster()` subscribes to `useExclusionsStore` changes. When exclusion rules change, it calls `useImportStore.recomputeCluster()`, which re-applies exclusions via `applyExclusions` + `aggregateVmRows` against the session-only `vmRowsByScope` and writes the kept VM aggregates back into `useClusterStore` while preserving ESX-derived fields (server config, utilization %).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -281,12 +281,12 @@ UI components are tested for behavior (rendering, interactions, conditional visi
 
 ## VM Exclusions Coverage (v2.7)
 
-The exclusions feature introduces ~60 new tests across 11 files, bringing the suite to ≈720 tests.
+The exclusions feature introduces ~60 new tests across 12 files, bringing the suite to ≈720 tests.
 
 | File | Focus |
 |---|---|
 | `src/lib/utils/import/__tests__/exclusions.compilePattern.test.ts` | glob→regex compilation, ReDoS safety, case-insensitive matching |
-| `src/lib/utils/import/__tests__/exclusions.isExcluded.test.ts` | short-circuit order (overrides → power → exact → glob) |
+| `src/lib/utils/import/__tests__/exclusions.isExcluded.test.ts` | short-circuit order (manual overrides → name pattern → exact names → power state); composite `${scopeKey}::${name}` targeting |
 | `src/lib/utils/import/__tests__/exclusions.apply.test.ts` | `applyExclusions` with stats breakdown |
 | `src/lib/utils/import/__tests__/exclusions.aggregate.test.ts` | `aggregateVmRows` aggregation correctness |
 | `src/lib/utils/import/__tests__/liveopticParser.vmRows.test.ts` | `vmRowsByScope` emission from LiveOptics |

--- a/src/components/exclusions/VirtualizedVmList.tsx
+++ b/src/components/exclusions/VirtualizedVmList.tsx
@@ -4,8 +4,8 @@ import { Checkbox } from '@/components/ui/checkbox'
 
 interface VirtualizedVmListProps {
   readonly rows: readonly VmRow[]
-  readonly excludedNames: ReadonlySet<string>
-  readonly onToggle: (name: string) => void
+  readonly excludedKeys: ReadonlySet<string>
+  readonly onToggle: (vmKey: string) => void
   readonly height: number
   readonly rowHeight: number
   readonly overscan?: number
@@ -13,7 +13,7 @@ interface VirtualizedVmListProps {
 
 export function VirtualizedVmList({
   rows,
-  excludedNames,
+  excludedKeys,
   onToggle,
   height,
   rowHeight,
@@ -46,30 +46,32 @@ export function VirtualizedVmList({
     >
       <div style={{ height: padTop }} aria-hidden />
       {slice.map((row) => {
-        const checked = excludedNames.has(row.name)
+        const vmKey = `${row.scopeKey}::${row.name}`
+        const checked = excludedKeys.has(vmKey)
         const ramGb = Math.round(row.ramMib / 1024)
         const diskGb = Math.round(row.diskMib / 1024)
         return (
-          <label
-            key={row.name}
-            className="flex items-center gap-2 px-2 text-sm"
-            style={{ height: rowHeight }}
+          <div
+            key={vmKey}
             role="listitem"
+            style={{ height: rowHeight }}
           >
-            <Checkbox
-              checked={checked}
-              onCheckedChange={() => onToggle(row.name)}
-            />
-            <span className="truncate flex-1 min-w-0" title={row.name}>
-              {row.name}
-            </span>
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              {row.vcpus} vCPU / {ramGb} GiB / {diskGb} GiB
-            </span>
-            {row.powerState === 'poweredOff' && (
-              <span className="text-xs text-muted-foreground whitespace-nowrap">(off)</span>
-            )}
-          </label>
+            <label className="flex items-center gap-2 px-2 text-sm h-full">
+              <Checkbox
+                checked={checked}
+                onCheckedChange={() => onToggle(vmKey)}
+              />
+              <span className="truncate flex-1 min-w-0" title={row.name}>
+                {row.name}
+              </span>
+              <span className="text-xs text-muted-foreground whitespace-nowrap">
+                {row.vcpus} vCPU / {ramGb} GiB / {diskGb} GiB
+              </span>
+              {row.powerState === 'poweredOff' && (
+                <span className="text-xs text-muted-foreground whitespace-nowrap">(off)</span>
+              )}
+            </label>
+          </div>
         )
       })}
       <div style={{ height: padBottom }} aria-hidden />

--- a/src/components/exclusions/VmExclusionPanel.tsx
+++ b/src/components/exclusions/VmExclusionPanel.tsx
@@ -19,6 +19,17 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
   const [reviewOpen, setReviewOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [showOnlyExcluded, setShowOnlyExcluded] = useState(false)
+  const [exactNamesText, setExactNamesText] = useState(() => rules.exactNames.join('\n'))
+  const [lastSyncedNames, setLastSyncedNames] = useState(rules.exactNames)
+  if (rules.exactNames !== lastSyncedNames) {
+    setLastSyncedNames(rules.exactNames)
+    setExactNamesText(rules.exactNames.join('\n'))
+  }
+
+  const commitExactNames = (): void => {
+    const parsed = exactNamesText.split('\n').map((s) => s.trim()).filter(Boolean)
+    setRules({ exactNames: parsed })
+  }
 
   const hasPowerState = rows.some((r) => r.powerState !== undefined)
 
@@ -28,9 +39,11 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
     return { filtered: filteredByScope.get('__all__') ?? [], stats }
   }, [rows, rules])
 
-  const excludedNames = useMemo(() => {
-    const keep = new Set(filtered.map((r) => r.name))
-    return new Set(rows.filter((r) => !keep.has(r.name)).map((r) => r.name))
+  const excludedKeys = useMemo(() => {
+    const keep = new Set(filtered.map((r) => `${r.scopeKey}::${r.name}`))
+    return new Set(
+      rows.filter((r) => !keep.has(`${r.scopeKey}::${r.name}`)).map((r) => `${r.scopeKey}::${r.name}`),
+    )
   }, [rows, filtered])
 
   const listedRows = useMemo(() => {
@@ -39,13 +52,13 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
       const q = search.toLowerCase()
       list = list.filter((r) => r.name.toLowerCase().includes(q))
     }
-    if (showOnlyExcluded) list = list.filter((r) => excludedNames.has(r.name))
+    if (showOnlyExcluded) list = list.filter((r) => excludedKeys.has(`${r.scopeKey}::${r.name}`))
     return list
-  }, [rows, search, showOnlyExcluded, excludedNames])
+  }, [rows, search, showOnlyExcluded, excludedKeys])
 
-  const handleRowToggle = (name: string): void => {
-    const kind = excludedNames.has(name) ? 'included' : 'excluded'
-    toggleManual(name, kind)
+  const handleRowToggle = (vmKey: string): void => {
+    const kind = excludedKeys.has(vmKey) ? 'included' : 'excluded'
+    toggleManual(vmKey, kind)
   }
 
   return (
@@ -66,10 +79,9 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
           Exact names
           <Textarea
             aria-label="Exact names"
-            value={rules.exactNames.join('\n')}
-            onChange={(e) => setRules({
-              exactNames: e.target.value.split('\n').map((s) => s.trim()).filter(Boolean),
-            })}
+            value={exactNamesText}
+            onChange={(e) => setExactNamesText(e.target.value)}
+            onBlur={commitExactNames}
             rows={3}
           />
         </label>
@@ -116,7 +128,7 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
           </div>
           <VirtualizedVmList
             rows={listedRows}
-            excludedNames={excludedNames}
+            excludedKeys={excludedKeys}
             onToggle={handleRowToggle}
             height={240}
             rowHeight={32}
@@ -128,6 +140,7 @@ export function VmExclusionPanel({ rows }: VmExclusionPanelProps) {
         <p>Excluded: {stats.excludedCount} of {stats.totalVms} VMs</p>
         <ul className="list-disc pl-5">
           <li>{stats.excludedByRule.namePattern} by name pattern</li>
+          <li>{stats.excludedByRule.exactNames} by exact name</li>
           <li>{stats.excludedByRule.powerState} powered-off</li>
           <li>{stats.excludedByRule.manual} manual</li>
         </ul>

--- a/src/components/exclusions/__tests__/VirtualizedVmList.test.tsx
+++ b/src/components/exclusions/__tests__/VirtualizedVmList.test.tsx
@@ -16,7 +16,7 @@ describe('VirtualizedVmList', () => {
     render(
       <VirtualizedVmList
         rows={rows}
-        excludedNames={new Set()}
+        excludedKeys={new Set()}
         onToggle={() => {}}
         height={400}
         rowHeight={32}
@@ -27,11 +27,11 @@ describe('VirtualizedVmList', () => {
     expect(rendered.length).toBeGreaterThan(0)
   })
 
-  it('marks row as excluded when the name is in excludedNames', () => {
+  it('marks row as excluded when its composite key is in excludedKeys', () => {
     render(
       <VirtualizedVmList
         rows={rows.slice(0, 10)}
-        excludedNames={new Set(['vm-3'])}
+        excludedKeys={new Set(['s1::vm-3'])}
         onToggle={() => {}}
         height={400}
         rowHeight={32}
@@ -42,12 +42,12 @@ describe('VirtualizedVmList', () => {
     expect(cb.getAttribute('aria-checked')).toBe('true')
   })
 
-  it('calls onToggle with the row name when a checkbox is clicked', () => {
+  it('calls onToggle with the composite scopeKey::name when a checkbox is clicked', () => {
     const onToggle = vi.fn()
     render(
       <VirtualizedVmList
         rows={rows.slice(0, 5)}
-        excludedNames={new Set()}
+        excludedKeys={new Set()}
         onToggle={onToggle}
         height={400}
         rowHeight={32}
@@ -55,14 +55,14 @@ describe('VirtualizedVmList', () => {
     )
     const cb = screen.getByRole('checkbox', { name: /vm-2/ })
     fireEvent.click(cb)
-    expect(onToggle).toHaveBeenCalledWith('vm-2')
+    expect(onToggle).toHaveBeenCalledWith('s1::vm-2')
   })
 
   it('updates the visible window when the container is scrolled', () => {
     const { container } = render(
       <VirtualizedVmList
         rows={rows}
-        excludedNames={new Set()}
+        excludedKeys={new Set()}
         onToggle={() => {}}
         height={400}
         rowHeight={32}

--- a/src/components/exclusions/__tests__/VmExclusionPanel.test.tsx
+++ b/src/components/exclusions/__tests__/VmExclusionPanel.test.tsx
@@ -60,8 +60,20 @@ describe('VmExclusionPanel', () => {
     const webCb = screen.getByRole('checkbox', { name: /^web01/ })
     expect(webCb).toHaveAttribute('aria-checked', 'false')
     fireEvent.click(webCb)
-    expect(useExclusionsStore.getState().rules.manuallyExcluded).toContain('web01')
+    expect(useExclusionsStore.getState().rules.manuallyExcluded).toContain('s1::web01')
     fireEvent.click(webCb)
-    expect(useExclusionsStore.getState().rules.manuallyExcluded).not.toContain('web01')
+    expect(useExclusionsStore.getState().rules.manuallyExcluded).not.toContain('s1::web01')
+  })
+
+  it('commits exactNames only on blur, preserving newlines mid-edit', () => {
+    render(<VmExclusionPanel rows={rows} />)
+    const ta = screen.getByLabelText(/Exact names/i) as HTMLTextAreaElement
+    fireEvent.change(ta, { target: { value: 'lab-a\nlab-b\n' } })
+    // Not committed yet — store still has empty exactNames
+    expect(useExclusionsStore.getState().rules.exactNames).toEqual([])
+    // Newline preserved in local text state
+    expect(ta.value).toBe('lab-a\nlab-b\n')
+    fireEvent.blur(ta)
+    expect(useExclusionsStore.getState().rules.exactNames).toEqual(['lab-a', 'lab-b'])
   })
 })

--- a/src/lib/utils/import/__tests__/exclusions.test.ts
+++ b/src/lib/utils/import/__tests__/exclusions.test.ts
@@ -97,24 +97,30 @@ describe('isExcluded', () => {
 
   it('manuallyIncluded overrides a pattern match', () => {
     const re = compileNamePattern('test-*')
-    const rules = { ...EMPTY_RULES, namePattern: 'test-*', manuallyIncluded: ['test-keep'] }
+    const rules = { ...EMPTY_RULES, namePattern: 'test-*', manuallyIncluded: ['s1::test-keep'] }
     expect(isExcluded(row('test-keep'), rules, re)).toBe(false)
     expect(isExcluded(row('test-other'), rules, re)).toBe(true)
   })
 
   it('manuallyIncluded overrides powered-off exclusion', () => {
-    const rules = { ...EMPTY_RULES, excludePoweredOff: true, manuallyIncluded: ['keep'] }
+    const rules = { ...EMPTY_RULES, excludePoweredOff: true, manuallyIncluded: ['s1::keep'] }
     expect(isExcluded(row('keep', { powerState: 'poweredOff' }), rules, null)).toBe(false)
   })
 
   it('manuallyExcluded wins over no-rule match', () => {
-    const rules = { ...EMPTY_RULES, manuallyExcluded: ['drop'] }
+    const rules = { ...EMPTY_RULES, manuallyExcluded: ['s1::drop'] }
     expect(isExcluded(row('drop'), rules, null)).toBe(true)
   })
 
   it('manuallyIncluded beats manuallyExcluded when both listed', () => {
-    const rules = { ...EMPTY_RULES, manuallyExcluded: ['x'], manuallyIncluded: ['x'] }
+    const rules = { ...EMPTY_RULES, manuallyExcluded: ['s1::x'], manuallyIncluded: ['s1::x'] }
     expect(isExcluded(row('x'), rules, null)).toBe(false)
+  })
+
+  it('manual override targets only the matching scope', () => {
+    const rules = { ...EMPTY_RULES, manuallyExcluded: ['dcA::dup'] }
+    expect(isExcluded(row('dup', { scopeKey: 'dcA' }), rules, null)).toBe(true)
+    expect(isExcluded(row('dup', { scopeKey: 'dcB' }), rules, null)).toBe(false)
   })
 })
 
@@ -132,7 +138,7 @@ describe('applyExclusions', () => {
     expect([...filteredByScope.get('s2')!].map((r) => r.name)).toEqual(['c'])
     expect(stats.totalVms).toBe(3)
     expect(stats.excludedCount).toBe(0)
-    expect(stats.excludedByRule).toEqual({ namePattern: 0, powerState: 0, manual: 0 })
+    expect(stats.excludedByRule).toEqual({ namePattern: 0, exactNames: 0, powerState: 0, manual: 0 })
   })
 
   it('preserves scope structure when all rows in a scope are excluded', () => {
@@ -156,10 +162,20 @@ describe('applyExclusions', () => {
     const rules = {
       ...EMPTY_RULES,
       namePattern: 'test-*',
-      manuallyExcluded: ['test-a'],
+      manuallyExcluded: ['s1::test-a'],
     }
     const { stats } = applyExclusions(input, rules)
     expect(stats.excludedByRule.manual).toBe(1)
+    expect(stats.excludedByRule.namePattern).toBe(1)
+  })
+
+  it('counts exact-name exclusions separately from name pattern', () => {
+    const input = new Map<string, VmRow[]>([
+      ['s1', rows(['lab-vm', 'test-a'])],
+    ])
+    const rules = { ...EMPTY_RULES, namePattern: 'test-*', exactNames: ['lab-vm'] }
+    const { stats } = applyExclusions(input, rules)
+    expect(stats.excludedByRule.exactNames).toBe(1)
     expect(stats.excludedByRule.namePattern).toBe(1)
   })
 
@@ -170,6 +186,18 @@ describe('applyExclusions', () => {
     const rules = { ...EMPTY_RULES, excludePoweredOff: true }
     const { stats } = applyExclusions(input, rules)
     expect(stats.excludedByRule.powerState).toBe(1)
+  })
+
+  it('manual override keyed by scope::name only hits the matching row', () => {
+    const input = new Map<string, VmRow[]>([
+      ['dcA', [row('dup', { scopeKey: 'dcA' })]],
+      ['dcB', [row('dup', { scopeKey: 'dcB' })]],
+    ])
+    const rules = { ...EMPTY_RULES, manuallyExcluded: ['dcA::dup'] }
+    const { filteredByScope, stats } = applyExclusions(input, rules)
+    expect(filteredByScope.get('dcA')).toEqual([])
+    expect(filteredByScope.get('dcB')!.map((r) => r.name)).toEqual(['dup'])
+    expect(stats.excludedByRule.manual).toBe(1)
   })
 })
 

--- a/src/lib/utils/import/exclusions.ts
+++ b/src/lib/utils/import/exclusions.ts
@@ -34,6 +34,10 @@ function escapeRegex(ch: string): string {
 
 /**
  * Decide whether a VM row is excluded.
+ *
+ * Manual overrides are keyed by `${row.scopeKey}::${row.name}` so that
+ * duplicate VM names across clusters/datacenters can be targeted individually.
+ *
  * Short-circuit order (first match wins):
  *   1. manuallyIncluded → false (override wins over every rule)
  *   2. manuallyExcluded → true
@@ -47,8 +51,9 @@ export function isExcluded(
   rules: ExclusionRules,
   compiled: RegExp | null,
 ): boolean {
-  if (rules.manuallyIncluded.includes(row.name)) return false
-  if (rules.manuallyExcluded.includes(row.name)) return true
+  const vmKey = `${row.scopeKey}::${row.name}`
+  if (rules.manuallyIncluded.includes(vmKey)) return false
+  if (rules.manuallyExcluded.includes(vmKey)) return true
   if (compiled !== null && compiled.test(row.name)) return true
   if (rules.exactNames.includes(row.name)) return true
   if (rules.excludePoweredOff && row.powerState === 'poweredOff') return true
@@ -60,6 +65,7 @@ export interface ExclusionStats {
   readonly excludedCount: number
   readonly excludedByRule: {
     readonly namePattern: number
+    readonly exactNames: number
     readonly powerState: number
     readonly manual: number
   }
@@ -81,6 +87,7 @@ export function applyExclusions(
 
   let totalVms = 0
   let byPattern = 0
+  let byExact = 0
   let byPower = 0
   let byManual = 0
 
@@ -88,11 +95,12 @@ export function applyExclusions(
     const kept: VmRow[] = []
     for (const row of rows) {
       totalVms++
-      if (includedSet.has(row.name)) {
+      const vmKey = `${row.scopeKey}::${row.name}`
+      if (includedSet.has(vmKey)) {
         kept.push(row)
         continue
       }
-      if (excludedSet.has(row.name)) {
+      if (excludedSet.has(vmKey)) {
         byManual++
         continue
       }
@@ -101,7 +109,7 @@ export function applyExclusions(
         continue
       }
       if (exactSet.has(row.name)) {
-        byPattern++
+        byExact++
         continue
       }
       if (rules.excludePoweredOff && row.powerState === 'poweredOff') {
@@ -117,8 +125,13 @@ export function applyExclusions(
     filteredByScope,
     stats: {
       totalVms,
-      excludedCount: byPattern + byPower + byManual,
-      excludedByRule: { namePattern: byPattern, powerState: byPower, manual: byManual },
+      excludedCount: byPattern + byExact + byPower + byManual,
+      excludedByRule: {
+        namePattern: byPattern,
+        exactNames: byExact,
+        powerState: byPower,
+        manual: byManual,
+      },
     },
   }
 }

--- a/src/store/__tests__/useExclusionsStore.test.ts
+++ b/src/store/__tests__/useExclusionsStore.test.ts
@@ -36,22 +36,32 @@ describe('useExclusionsStore', () => {
     expect(useExclusionsStore.getState().rules.excludePoweredOff).toBe(false)
   })
 
-  it('toggleManual adds a name to manuallyExcluded and removes from manuallyIncluded', () => {
-    useExclusionsStore.getState().setRules({ manuallyIncluded: ['vm-a'] })
-    useExclusionsStore.getState().toggleManual('vm-a', 'excluded')
+  it('toggleManual adds a composite key to manuallyExcluded and removes from manuallyIncluded', () => {
+    useExclusionsStore.getState().setRules({ manuallyIncluded: ['s1::vm-a'] })
+    useExclusionsStore.getState().toggleManual('s1::vm-a', 'excluded')
     const rules = useExclusionsStore.getState().rules
-    expect(rules.manuallyExcluded).toContain('vm-a')
-    expect(rules.manuallyIncluded).not.toContain('vm-a')
+    expect(rules.manuallyExcluded).toContain('s1::vm-a')
+    expect(rules.manuallyIncluded).not.toContain('s1::vm-a')
   })
 
   it('toggleManual removes the entry when it already matches the target state', () => {
-    useExclusionsStore.getState().setRules({ manuallyExcluded: ['vm-a'] })
-    useExclusionsStore.getState().toggleManual('vm-a', 'excluded')
-    expect(useExclusionsStore.getState().rules.manuallyExcluded).not.toContain('vm-a')
+    useExclusionsStore.getState().setRules({ manuallyExcluded: ['s1::vm-a'] })
+    useExclusionsStore.getState().toggleManual('s1::vm-a', 'excluded')
+    expect(useExclusionsStore.getState().rules.manuallyExcluded).not.toContain('s1::vm-a')
+  })
+
+  it('toggleManual scopes are independent across scopeKey prefixes', () => {
+    useExclusionsStore.getState().toggleManual('dcA::dup', 'excluded')
+    useExclusionsStore.getState().toggleManual('dcB::dup', 'excluded')
+    const rules = useExclusionsStore.getState().rules
+    expect(rules.manuallyExcluded).toContain('dcA::dup')
+    expect(rules.manuallyExcluded).toContain('dcB::dup')
+    useExclusionsStore.getState().toggleManual('dcA::dup', 'excluded')
+    expect(useExclusionsStore.getState().rules.manuallyExcluded).toEqual(['dcB::dup'])
   })
 
   it('reset restores EMPTY_RULES', () => {
-    useExclusionsStore.getState().setRules({ namePattern: 'test-*', manuallyExcluded: ['x'] })
+    useExclusionsStore.getState().setRules({ namePattern: 'test-*', manuallyExcluded: ['s1::x'] })
     useExclusionsStore.getState().reset()
     expect(useExclusionsStore.getState().rules).toEqual(EMPTY_RULES)
   })

--- a/src/store/useExclusionsStore.ts
+++ b/src/store/useExclusionsStore.ts
@@ -6,7 +6,8 @@ import { EMPTY_RULES } from '@/types/exclusions'
 interface ExclusionsState {
   rules: ExclusionRules
   setRules: (partial: Partial<ExclusionRules>) => void
-  toggleManual: (vmName: string, kind: 'excluded' | 'included') => void
+  /** vmKey is `${scopeKey}::${name}` so overrides target one row even with duplicate VM names across scopes. */
+  toggleManual: (vmKey: string, kind: 'excluded' | 'included') => void
   reset: () => void
 }
 
@@ -17,18 +18,18 @@ export const useExclusionsStore = create<ExclusionsState>()(
       setRules: (partial) => {
         set({ rules: { ...get().rules, ...partial } })
       },
-      toggleManual: (vmName, kind) => {
+      toggleManual: (vmKey, kind) => {
         const rules = get().rules
         const listKey = kind === 'excluded' ? 'manuallyExcluded' : 'manuallyIncluded'
         const otherKey = kind === 'excluded' ? 'manuallyIncluded' : 'manuallyExcluded'
         const list = rules[listKey]
         const other = rules[otherKey]
-        const isOn = list.includes(vmName)
+        const isOn = list.includes(vmKey)
         set({
           rules: {
             ...rules,
-            [listKey]: isOn ? list.filter((n) => n !== vmName) : [...list, vmName],
-            [otherKey]: other.filter((n) => n !== vmName),
+            [listKey]: isOn ? list.filter((k) => k !== vmKey) : [...list, vmKey],
+            [otherKey]: other.filter((k) => k !== vmKey),
           },
         })
       },
@@ -36,11 +37,25 @@ export const useExclusionsStore = create<ExclusionsState>()(
     }),
     {
       name: 'presizion-exclusions-v1',
-      version: 1,
+      version: 2,
       storage: createJSONStorage(() => globalThis.localStorage),
       migrate: (persistedState, version) => {
-        if (version !== 1) return { rules: EMPTY_RULES }
-        return persistedState as ExclusionsState
+        if (version === 2) return persistedState as ExclusionsState
+        // v1 → v2: manual lists held bare VM names; we can't retroactively map
+        // them to `${scopeKey}::${name}` without the original import context,
+        // so drop the manual lists but preserve the rule-based fields.
+        if (version === 1 && persistedState != null && typeof persistedState === 'object') {
+          const prior = (persistedState as { rules?: Partial<ExclusionRules> }).rules ?? {}
+          return {
+            rules: {
+              ...EMPTY_RULES,
+              namePattern: prior.namePattern ?? '',
+              exactNames: prior.exactNames ?? [],
+              excludePoweredOff: prior.excludePoweredOff ?? false,
+            },
+          } as ExclusionsState
+        }
+        return { rules: EMPTY_RULES } as ExclusionsState
       },
     },
   ),


### PR DESCRIPTION
## Summary

Follow-up to #14 addressing 12 CodeRabbit inline findings (3 major, 9 minor).

- **Textarea newline preservation**: local state via adjust-during-render pattern — no more stripped newlines mid-edit.
- **Scope-aware VM identity**: manual overrides use composite keys `${scopeKey}::${name}` so duplicate VM names across clusters target independently. `useExclusionsStore` persist version 1 → 2 with migration dropping v1 manual lists.
- **Exact-name stats row**: separate `byPattern` and `exactNames` counters in `ExclusionStats.excludedByRule`.
- **a11y**: `role="listitem"` moved off interactive `<label>` onto wrapping `<div>`.
- **Docs**: architecture/import-export/state-management/testing aligned with shipped API. ADR-021 cleaned up via `markdownlint-cli2 --fix`.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx tsc -b --noEmit` — clean
- [x] `vitest run` — 726/726 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)