### PR TITLE
feat(import): detect stretch clusters from scope and host signals

### DIFF
--- a/src/components/step1/CurrentClusterForm.tsx
+++ b/src/components/step1/CurrentClusterForm.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Switch } from '@/components/ui/switch'
 import {
   Tooltip,
   TooltipContent,
@@ -45,6 +46,7 @@ const TOOLTIPS: Record<keyof CurrentClusterInput, string> = {
   cpuUtilizationPercent: 'Current average CPU utilization percent (0–100). Used to scale effective vCPU demand.',
   ramUtilizationPercent: 'Current average RAM utilization percent (0–100). Used to scale effective RAM demand.',
   cpuFrequencyGhz: 'Average CPU clock frequency of existing servers in GHz. Auto-filled from RVTools/LiveOptics import when available.',
+  isStretchCluster: 'Stretched cluster: each site must carry the full workload on failure. Sizing doubles the server count and rounds up to an even number.',
 }
 
 interface NumericFieldProps {
@@ -53,6 +55,13 @@ interface NumericFieldProps {
   label: string
   testId: string
   optional?: boolean
+}
+
+/** Coerce form field values (which may include boolean for isStretchCluster) to a number-input-safe string. */
+function toInputValue(val: unknown, optional: boolean): string | number {
+  if (typeof val === 'boolean') return ''
+  if (val == null) return optional ? '' : 0
+  return val as string | number
 }
 
 function NumericFormField({ control, name, label, testId, optional }: NumericFieldProps) {
@@ -84,7 +93,7 @@ function NumericFormField({ control, name, label, testId, optional }: NumericFie
               min={0}
               data-testid={testId}
               {...field}
-              value={optional ? (field.value ?? '') : field.value}
+              value={toInputValue(field.value, optional ?? false)}
               onChange={(e) => field.onChange(e.target.value)}
             />
           </FormControl>
@@ -138,7 +147,7 @@ function CheckboxNumericField({
               data-testid={testId}
               disabled={!enabled}
               {...field}
-              value={enabled ? (field.value ?? '') : ''}
+              value={enabled ? toInputValue(field.value, true) : ''}
               onChange={(e) => field.onChange(e.target.value)}
             />
           </FormControl>
@@ -181,6 +190,7 @@ export function CurrentClusterForm({ onNext }: CurrentClusterFormProps) {
       ramUtilizationPercent: undefined,
       existingServerCount: undefined,
       cpuFrequencyGhz: undefined,
+      isStretchCluster: undefined,
     },
   })
 
@@ -199,7 +209,8 @@ export function CurrentClusterForm({ onNext }: CurrentClusterFormProps) {
       formVals.cpuUtilizationPercent !== currentCluster.cpuUtilizationPercent ||
       formVals.ramUtilizationPercent !== currentCluster.ramUtilizationPercent ||
       formVals.specintPerServer !== currentCluster.specintPerServer ||
-      formVals.cpuFrequencyGhz !== currentCluster.cpuFrequencyGhz
+      formVals.cpuFrequencyGhz !== currentCluster.cpuFrequencyGhz ||
+      formVals.isStretchCluster !== currentCluster.isStretchCluster
     if (changed) {
       form.reset({
         ...formVals,
@@ -215,6 +226,7 @@ export function CurrentClusterForm({ onNext }: CurrentClusterFormProps) {
         ramUtilizationPercent: currentCluster.ramUtilizationPercent,
         specintPerServer: currentCluster.specintPerServer,
         cpuFrequencyGhz: currentCluster.cpuFrequencyGhz,
+        isStretchCluster: currentCluster.isStretchCluster,
       })
       // Sync checkbox enabled state when cluster is imported
       if (currentCluster.cpuUtilizationPercent !== undefined) setCpuUtilEnabled(true)
@@ -360,6 +372,35 @@ export function CurrentClusterForm({ onNext }: CurrentClusterFormProps) {
             <NumericFormField control={form.control} name="coresPerSocket" label="Cores/Socket (physical)" testId="input-coresPerSocket" optional />
             <NumericFormField control={form.control} name="ramPerServerGb" label="RAM/Server GB" testId="input-ramPerServerGb" optional />
           </div>
+          <FormField
+            control={form.control}
+            name="isStretchCluster"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-3 mt-4">
+                <FormControl>
+                  <Switch
+                    checked={field.value === true}
+                    onCheckedChange={(v) => field.onChange(v)}
+                    aria-label="Stretch cluster"
+                    data-testid="input-isStretchCluster"
+                  />
+                </FormControl>
+                <FormLabel className="flex items-center gap-1 !mt-0 cursor-pointer">
+                  Stretch cluster
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" aria-label="Info: Stretch cluster" />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="max-w-xs text-sm">{TOOLTIPS.isStretchCluster}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </FormLabel>
+              </FormItem>
+            )}
+          />
         </section>
 
         <section>

--- a/src/components/step1/ImportPreviewModal.tsx
+++ b/src/components/step1/ImportPreviewModal.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/components/ui/drawer'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
 import { useClusterStore } from '@/store/useClusterStore'
 import { useScenariosStore } from '@/store/useScenariosStore'
 import { useImportStore } from '@/store/useImportStore'
@@ -87,11 +89,14 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
   const [prevResult, setPrevResult] = useState<AnyImportResult>(result)
   const [selectedScopes, setSelectedScopes] = useState<string[]>(scopesFromResult)
   const [step, setStep] = useState<'scope' | 'exclusions'>('scope')
+  const initialStretch = !isJson && result.isStretchCluster === true
+  const [stretchConfirmed, setStretchConfirmed] = useState<boolean>(initialStretch)
 
   if (prevResult !== result) {
     setPrevResult(result)
     setSelectedScopes(scopesFromResult)
     setStep('scope')
+    setStretchConfirmed(initialStretch)
   }
 
   const canShowExclusions =
@@ -125,6 +130,7 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
         ...(previewCluster.ramUtilizationPercent != null && { ramUtilizationPercent: previewCluster.ramUtilizationPercent }),
         ...(previewCluster.cpuModel != null && { cpuModel: previewCluster.cpuModel }),
         ...(previewCluster.cpuFrequencyGhz != null && { cpuFrequencyGhz: previewCluster.cpuFrequencyGhz }),
+        ...(stretchConfirmed && { isStretchCluster: true }),
       }
       setCurrentCluster(cluster)
       seedFromCluster(cluster)
@@ -160,6 +166,29 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
           onToggle={handleToggle}
           rawByScope={'rawByScope' in result ? result.rawByScope ?? undefined : undefined}
         />
+      )}
+
+      {!isJson && (result.isStretchCluster === true || stretchConfirmed) && (
+        <div className="flex items-start gap-2 p-2 rounded border border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20">
+          <div className="flex-1 space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">Stretch cluster detected</Badge>
+              <Switch
+                checked={stretchConfirmed}
+                onCheckedChange={setStretchConfirmed}
+                aria-label="Confirm stretch cluster topology"
+              />
+            </div>
+            {result.stretchSignals && result.stretchSignals.length > 0 && (
+              <ul className="text-xs text-muted-foreground list-disc list-inside space-y-0.5">
+                {result.stretchSignals.map((s, i) => <li key={i}>{s}</li>)}
+              </ul>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Sizing will double the server count for site symmetry.
+            </p>
+          </div>
+        </div>
       )}
 
       <div className="space-y-1 text-sm">

--- a/src/components/step1/ImportPreviewModal.tsx
+++ b/src/components/step1/ImportPreviewModal.tsx
@@ -130,7 +130,7 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
         ...(previewCluster.ramUtilizationPercent != null && { ramUtilizationPercent: previewCluster.ramUtilizationPercent }),
         ...(previewCluster.cpuModel != null && { cpuModel: previewCluster.cpuModel }),
         ...(previewCluster.cpuFrequencyGhz != null && { cpuFrequencyGhz: previewCluster.cpuFrequencyGhz }),
-        ...(stretchConfirmed && { isStretchCluster: true }),
+        ...(previewCluster.isStretchCluster === true && stretchConfirmed && { isStretchCluster: true }),
       }
       setCurrentCluster(cluster)
       seedFromCluster(cluster)
@@ -168,7 +168,7 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
         />
       )}
 
-      {!isJson && (result.isStretchCluster === true || stretchConfirmed) && (
+      {!isJson && previewCluster.isStretchCluster === true && (
         <div className="flex items-start gap-2 p-2 rounded border border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20">
           <div className="flex-1 space-y-1">
             <div className="flex items-center gap-2">
@@ -179,9 +179,9 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
                 aria-label="Confirm stretch cluster topology"
               />
             </div>
-            {result.stretchSignals && result.stretchSignals.length > 0 && (
+            {previewCluster.stretchSignals && previewCluster.stretchSignals.length > 0 && (
               <ul className="text-xs text-muted-foreground list-disc list-inside space-y-0.5">
-                {result.stretchSignals.map((s, i) => <li key={i}>{s}</li>)}
+                {previewCluster.stretchSignals.map((s) => <li key={s}>{s}</li>)}
               </ul>
             )}
             <p className="text-xs text-muted-foreground">

--- a/src/components/step3/NodeSizingRows.tsx
+++ b/src/components/step3/NodeSizingRows.tsx
@@ -32,22 +32,30 @@ export function NodeSizingRows({ cluster, scenarios, results, sizingMode }: Node
         <TableCell className={ASIS}>
           {cluster.existingServerCount ?? '—'}
         </TableCell>
-        {results.map((result, i) => (
-          <TableCell key={scenarios[i]?.id ?? i} className="text-center">
-            {result.haReserveApplied ? (
-              <span>
-                {result.requiredCount}
-                <span className="text-xs text-muted-foreground ml-1">
-                  + {result.haReserveCount} (N+{result.haReserveCount})
+        {results.map((result, i) => {
+          const base = result.stretchApplied && result.stretchPairedCount != null
+            ? result.stretchPairedCount
+            : result.requiredCount
+          const baseLabel = result.stretchApplied
+            ? `${result.requiredCount}×2`
+            : `${result.requiredCount}`
+          return (
+            <TableCell key={scenarios[i]?.id ?? i} className="text-center">
+              {result.haReserveApplied ? (
+                <span>
+                  {result.stretchApplied ? `${baseLabel}=${base}` : base}
+                  <span className="text-xs text-muted-foreground ml-1">
+                    + {result.haReserveCount} (N+{result.haReserveCount})
+                  </span>
+                  {' = '}
+                  <span className="font-semibold">{result.finalCount}</span>
                 </span>
-                {' = '}
-                <span className="font-semibold">{result.finalCount}</span>
-              </span>
-            ) : (
-              result.finalCount
-            )}
-          </TableCell>
-        ))}
+              ) : (
+                result.finalCount
+              )}
+            </TableCell>
+          )
+        })}
       </TableRow>
 
       {/* Server Config */}

--- a/src/lib/sizing/__tests__/constraints.test.ts
+++ b/src/lib/sizing/__tests__/constraints.test.ts
@@ -709,4 +709,85 @@ describe('Growth factor wiring (Phase 19)', () => {
   });
 });
 
+// =====================================================================
+// Stretch cluster: topology-aware sizing (CALC-STRETCH)
+// =====================================================================
+
+describe('computeScenarioResult — stretch cluster', () => {
+  it('isStretchCluster=true doubles finalCount and sets stretchApplied', () => {
+    // CPU_LIMITED rawCount = 24. Stretched → pairedCount = 48, finalCount = 48 (no HA).
+    const stretchedCluster = { ...CPU_LIMITED_CLUSTER, isStretchCluster: true };
+    const result = computeScenarioResult(stretchedCluster, CPU_LIMITED_SCENARIO);
+    expect(result.rawCount).toBe(24);
+    expect(result.stretchApplied).toBe(true);
+    expect(result.stretchPairedCount).toBe(48);
+    expect(result.finalCount).toBe(48);
+  });
+
+  it('isStretchCluster=true preserves requiredCount (pre-stretch demand)', () => {
+    const stretchedCluster = { ...CPU_LIMITED_CLUSTER, isStretchCluster: true };
+    const result = computeScenarioResult(stretchedCluster, CPU_LIMITED_SCENARIO);
+    expect(result.requiredCount).toBe(24); // capacity-actual demand; site symmetry is on top
+  });
+
+  it('stretch + haReserveCount=1 adds the reserve on top of the paired count', () => {
+    const stretchedCluster = { ...CPU_LIMITED_CLUSTER, isStretchCluster: true };
+    const stretchedScenario = { ...CPU_LIMITED_SCENARIO, haReserveCount: 1 as const };
+    const result = computeScenarioResult(stretchedCluster, stretchedScenario);
+    expect(result.stretchPairedCount).toBe(48);
+    expect(result.finalCount).toBe(49); // 48 paired + 1 reserve
+    expect(result.haReserveApplied).toBe(true);
+  });
+
+  it('stretch + haReserveCount=0 gives paired count exactly (stretch IS the HA mechanism)', () => {
+    const stretchedCluster = { ...CPU_LIMITED_CLUSTER, isStretchCluster: true };
+    const result = computeScenarioResult(stretchedCluster, CPU_LIMITED_SCENARIO);
+    expect(result.finalCount).toBe(48);
+    expect(result.haReserveApplied).toBe(false);
+  });
+
+  it('stretch respects minServerCount floor when paired count is smaller', () => {
+    const stretchedCluster = { ...RAM_LIMITED_CLUSTER, isStretchCluster: true };
+    const pinnedScenario = { ...RAM_LIMITED_SCENARIO, minServerCount: 100 };
+    const result = computeScenarioResult(stretchedCluster, pinnedScenario);
+    // RAM_LIMITED rawCount = 19, paired = 38, floor = 100 → finalCount = 100
+    expect(result.stretchPairedCount).toBe(38);
+    expect(result.finalCount).toBe(100);
+  });
+
+  it('stretch odd rawCount still produces even pairedCount (rawCount*2 is always even)', () => {
+    // RAM_LIMITED rawCount = 19 (odd). 19*2 = 38, already even.
+    const stretchedCluster = { ...RAM_LIMITED_CLUSTER, isStretchCluster: true };
+    const result = computeScenarioResult(stretchedCluster, RAM_LIMITED_SCENARIO);
+    expect(result.rawCount).toBe(19);
+    expect(result.stretchPairedCount).toBe(38);
+    expect(result.stretchPairedCount! % 2).toBe(0);
+  });
+
+  it('cluster without isStretchCluster: stretchApplied=false, no doubling (regression)', () => {
+    const result = computeScenarioResult(CPU_LIMITED_CLUSTER, CPU_LIMITED_SCENARIO);
+    expect(result.stretchApplied).toBe(false);
+    expect(result.stretchPairedCount).toBeUndefined();
+    expect(result.finalCount).toBe(24);
+  });
+
+  it('isStretchCluster=false explicitly: same as absent (regression)', () => {
+    const notStretched = { ...CPU_LIMITED_CLUSTER, isStretchCluster: false };
+    const result = computeScenarioResult(notStretched, CPU_LIMITED_SCENARIO);
+    expect(result.stretchApplied).toBe(false);
+    expect(result.finalCount).toBe(24);
+  });
+
+  it('stretch + SPECint mode: pre-stretch count from specint formula, then doubled', () => {
+    // SPECint: cpuLimitedCount=6, ram=1, disk=1 → rawCount=6; stretched → 12.
+    const stretchedSpecintCluster = { ...SPECINT_CLUSTER, isStretchCluster: true };
+    const result = computeScenarioResult(stretchedSpecintCluster, SPECINT_SCENARIO, 'specint');
+    expect(result.cpuLimitedCount).toBe(6);
+    expect(result.rawCount).toBe(6);
+    expect(result.stretchPairedCount).toBe(12);
+    expect(result.finalCount).toBe(12);
+    expect(result.limitingResource).toBe('specint');
+  });
+});
+
 export { CPU_LIMITED_CLUSTER, CPU_LIMITED_SCENARIO, RAM_LIMITED_CLUSTER, RAM_LIMITED_SCENARIO, DISK_LIMITED_CLUSTER, DISK_LIMITED_SCENARIO };

--- a/src/lib/sizing/constraints.ts
+++ b/src/lib/sizing/constraints.ts
@@ -201,16 +201,15 @@ export function computeScenarioResult(
   // CALC-05: Raw count is the maximum of all active constraints
   const rawCount = Math.max(cpuLimitedCount, ramLimitedCount, diskLimitedCount);
 
-  // CALC-STRETCH: stretched topology — each site must carry the full workload.
-  // Double the raw count and round up to an even number for site symmetry.
-  // Stretch provides site-level fault tolerance; any explicit haReserveCount
-  // set by the user adds on top (belt-and-suspenders) but is not implied.
+  // CALC-STRETCH: stretched topology — each site must carry the full workload,
+  // so the raw count is doubled for site symmetry. Stretch provides site-level
+  // fault tolerance; any explicit haReserveCount set by the user adds on top
+  // (belt-and-suspenders) but is not implied.
   const stretchApplied = cluster.isStretchCluster === true;
   let effectiveRaw = rawCount;
   let stretchPairedCount: number | undefined;
   if (stretchApplied) {
     effectiveRaw = rawCount * 2;
-    if (effectiveRaw % 2 !== 0) effectiveRaw += 1;
     stretchPairedCount = effectiveRaw;
   }
 

--- a/src/lib/sizing/constraints.ts
+++ b/src/lib/sizing/constraints.ts
@@ -201,9 +201,22 @@ export function computeScenarioResult(
   // CALC-05: Raw count is the maximum of all active constraints
   const rawCount = Math.max(cpuLimitedCount, ramLimitedCount, diskLimitedCount);
 
+  // CALC-STRETCH: stretched topology — each site must carry the full workload.
+  // Double the raw count and round up to an even number for site symmetry.
+  // Stretch provides site-level fault tolerance; any explicit haReserveCount
+  // set by the user adds on top (belt-and-suspenders) but is not implied.
+  const stretchApplied = cluster.isStretchCluster === true;
+  let effectiveRaw = rawCount;
+  let stretchPairedCount: number | undefined;
+  if (stretchApplied) {
+    effectiveRaw = rawCount * 2;
+    if (effectiveRaw % 2 !== 0) effectiveRaw += 1;
+    stretchPairedCount = effectiveRaw;
+  }
+
   // CALC-04: HA reserve — add 0, 1, or 2 servers after the constraint max
   const haReserveCount = scenario.haReserveCount ?? 0;
-  const withHA = rawCount + haReserveCount;
+  const withHA = effectiveRaw + haReserveCount;
 
   // Pin floor: finalCount is never less than minServerCount when set
   const finalCount =
@@ -256,5 +269,7 @@ export function computeScenarioResult(
     cpuUtilizationPercent,
     ramUtilizationPercent,
     diskUtilizationPercent,
+    stretchApplied,
+    ...(stretchPairedCount !== undefined && { stretchPairedCount }),
   });
 }

--- a/src/lib/utils/__tests__/export.test.ts
+++ b/src/lib/utils/__tests__/export.test.ts
@@ -42,6 +42,7 @@ const result: ScenarioResult = {
   cpuUtilizationPercent: 85.0,
   ramUtilizationPercent: 60.0,
   diskUtilizationPercent: 35.0,
+  stretchApplied: false,
 }
 
 beforeEach(() => {
@@ -151,6 +152,19 @@ describe('buildJsonContent', () => {
     const json = buildJsonContent(cluster, [scenario], [result])
     const parsed = JSON.parse(json) as { schemaVersion: string }
     expect(parsed.schemaVersion).toBe('2')
+  })
+
+  it('includes isStretchCluster (true) when set on the cluster', () => {
+    const stretched: OldCluster = { ...cluster, isStretchCluster: true }
+    const json = buildJsonContent(stretched, [scenario], [result])
+    const parsed = JSON.parse(json) as { currentCluster: Record<string, unknown> }
+    expect(parsed.currentCluster).toHaveProperty('isStretchCluster', true)
+  })
+
+  it('writes isStretchCluster as null when absent', () => {
+    const json = buildJsonContent(cluster, [scenario], [result])
+    const parsed = JSON.parse(json) as { currentCluster: Record<string, unknown> }
+    expect(parsed.currentCluster).toHaveProperty('isStretchCluster', null)
   })
 })
 

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -143,6 +143,7 @@ function normaliseCluster(
     specintPerServer: cluster.specintPerServer ?? null,
     cpuUtilizationPercent: cluster.cpuUtilizationPercent ?? null,
     ramUtilizationPercent: cluster.ramUtilizationPercent ?? null,
+    isStretchCluster: cluster.isStretchCluster ?? null,
   }
 }
 

--- a/src/lib/utils/import/__tests__/scopeAggregator.test.ts
+++ b/src/lib/utils/import/__tests__/scopeAggregator.test.ts
@@ -204,4 +204,23 @@ describe('aggregateScopes', () => {
     expect(result.warnings).toContain('Warning B1')
     expect(result.warnings).toHaveLength(3)
   })
+
+  it('stretched flag on any selected scope poisons the aggregate', () => {
+    const map = new Map<string, ScopeEntry>([
+      ['CL-A', makeScope({ vmCount: 1, isStretchCluster: true, stretchSignals: ['vSAN says stretched'] })],
+      ['CL-B', makeScope({ vmCount: 1 })],
+    ])
+    const result = aggregateScopes(map, ['CL-A', 'CL-B'])
+    expect(result.isStretchCluster).toBe(true)
+    expect(result.stretchSignals).toContain('vSAN says stretched')
+  })
+
+  it('no stretched scope → no stretch flag on aggregate', () => {
+    const map = new Map<string, ScopeEntry>([
+      ['CL-A', makeScope({ vmCount: 1 })],
+      ['CL-B', makeScope({ vmCount: 1 })],
+    ])
+    const result = aggregateScopes(map, ['CL-A', 'CL-B'])
+    expect(result.isStretchCluster).toBeUndefined()
+  })
 })

--- a/src/lib/utils/import/__tests__/stretchClusterDetector.test.ts
+++ b/src/lib/utils/import/__tests__/stretchClusterDetector.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeStretchCluster } from '../stretchClusterDetector';
+
+describe('analyzeStretchCluster', () => {
+  it('returns high confidence when vSAN sheet explicitly marks stretched', () => {
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|cluster-01',
+      scopeLabel: 'cluster-01',
+      explicitStretchFromVsan: true,
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('high');
+    expect(result.signals).toContain('vSAN sheet marks cluster as stretched');
+  });
+
+  it('returns high confidence when vSAN sheet shows ≥2 fault domains', () => {
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|cluster-01',
+      scopeLabel: 'cluster-01',
+      faultDomainCount: 2,
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('high');
+    expect(result.signals[0]).toMatch(/2 fault domains/);
+  });
+
+  it('returns medium confidence for 2 DCs with symmetric host counts', () => {
+    const hostCountByDc = new Map([
+      ['dc-a', 8],
+      ['dc-b', 8],
+    ]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a+dc-b|cluster-01',
+      scopeLabel: 'cluster-01',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('within 25% tolerance counts as symmetric (8 vs 10)', () => {
+    const hostCountByDc = new Map([
+      ['dc-a', 8],
+      ['dc-b', 10],
+    ]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a+dc-b|cluster-01',
+      scopeLabel: 'cluster-01',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('upgrades to high confidence when 2-DC symmetric AND name matches', () => {
+    const hostCountByDc = new Map([
+      ['dc-a', 8],
+      ['dc-b', 8],
+    ]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a+dc-b|Metro-Cluster',
+      scopeLabel: 'Metro-Cluster',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('high');
+    expect(result.signals.some((s) => s.includes('metro'))).toBe(true);
+  });
+
+  it('returns medium confidence for name keyword match alone', () => {
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|stretched-prod',
+      scopeLabel: 'stretched-prod',
+    });
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('asymmetric 2-DC host distribution without name match is not stretched', () => {
+    // 4 vs 16 is 75% off — not symmetric
+    const hostCountByDc = new Map([
+      ['dc-a', 4],
+      ['dc-b', 16],
+    ]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a+dc-b|prod',
+      scopeLabel: 'prod',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(false);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('single-DC cluster without signals is not stretched', () => {
+    const hostCountByDc = new Map([['dc-a', 10]]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|cluster-01',
+      scopeLabel: 'cluster-01',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(false);
+    expect(result.confidence).toBe('low');
+    expect(result.signals).toEqual([]);
+  });
+
+  it('3-DC topology is not treated as stretched (stretched is strictly 2-site)', () => {
+    const hostCountByDc = new Map([
+      ['dc-a', 8],
+      ['dc-b', 8],
+      ['dc-c', 8],
+    ]);
+    const result = analyzeStretchCluster({
+      scopeKey: 'multi|cluster',
+      scopeLabel: 'cluster',
+      hostCountByDc,
+    });
+    expect(result.isStretchCluster).toBe(false);
+  });
+
+  it('faultDomainCount of 1 does not trigger', () => {
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|cluster',
+      scopeLabel: 'cluster',
+      faultDomainCount: 1,
+    });
+    expect(result.isStretchCluster).toBe(false);
+  });
+
+  it('explicitStretchFromVsan=false does not override other weak signals', () => {
+    const result = analyzeStretchCluster({
+      scopeKey: 'dc-a|stretched-prod',
+      scopeLabel: 'stretched-prod',
+      explicitStretchFromVsan: false,
+    });
+    // Name keyword still fires — we only short-circuit on true
+    expect(result.isStretchCluster).toBe(true);
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('keyword match is case-insensitive and word-bounded', () => {
+    const positives = ['Stretch', 'STRETCHED', 'Metro'];
+    const negatives = ['production', 'dev-stretcher', 'metropark'];
+    for (const label of positives) {
+      expect(analyzeStretchCluster({ scopeKey: 'k', scopeLabel: label }).isStretchCluster).toBe(true);
+    }
+    for (const label of negatives) {
+      expect(analyzeStretchCluster({ scopeKey: 'k', scopeLabel: label }).isStretchCluster).toBe(false);
+    }
+  });
+});

--- a/src/lib/utils/import/columnResolver.ts
+++ b/src/lib/utils/import/columnResolver.ts
@@ -50,6 +50,13 @@ export const CLUSTER_ALIASES: ColumnAliasMap = {
   cluster_name: ['Cluster', 'cluster', 'ClusterName', 'cluster_name', 'Cluster Name'],
 }
 
+export const RVTOOLS_VSAN_ALIASES: ColumnAliasMap = {
+  cluster_name: ['Cluster', 'Cluster Name'],
+  fault_domain: ['Fault Domain', 'FaultDomain', 'Fault-Domain'],
+  stretched:    ['Stretched Cluster', 'Stretched', 'IsStretched', 'Is Stretched'],
+  witness:      ['Witness Host', 'Witness', 'Witness Node'],
+}
+
 export const DATACENTER_ALIASES: ColumnAliasMap = {
   datacenter_name: ['Datacenter', 'datacenter', 'DC', 'DataCenter', 'data_center'],
 }

--- a/src/lib/utils/import/index.ts
+++ b/src/lib/utils/import/index.ts
@@ -29,6 +29,9 @@ export interface ClusterImportResult {
   ramUtilizationPercent?: number
   cpuFrequencyGhz?: number   // avg CPU clock frequency in GHz (from vHost / ESX Hosts)
   cpuModel?: string           // display-only CPU model string from first host
+  // Topology detection (Phase: stretch cluster)
+  isStretchCluster?: boolean  // detected stretched-cluster topology (vSAN sheet or heuristics)
+  stretchSignals?: string[]   // human-readable reasons feeding the preview tooltip
   // Scope detection fields — populated by parsers
   detectedScopes?: string[]
   scopeLabels?: Record<string, string>

--- a/src/lib/utils/import/jsonParser.ts
+++ b/src/lib/utils/import/jsonParser.ts
@@ -47,6 +47,7 @@ export function parsePresizionJson(buffer: ArrayBuffer): JsonImportResult {
     ...(c.specintPerServer != null && { specintPerServer: num(c.specintPerServer, 'specintPerServer') }),
     ...(c.cpuUtilizationPercent != null && { cpuUtilizationPercent: num(c.cpuUtilizationPercent, 'cpuUtilizationPercent') }),
     ...(c.ramUtilizationPercent != null && { ramUtilizationPercent: num(c.ramUtilizationPercent, 'ramUtilizationPercent') }),
+    ...(typeof c.isStretchCluster === 'boolean' && { isStretchCluster: c.isStretchCluster }),
   }
 
   if (!Array.isArray(scenarios)) {

--- a/src/lib/utils/import/liveopticParser.ts
+++ b/src/lib/utils/import/liveopticParser.ts
@@ -9,6 +9,7 @@ import {
 } from './columnResolver'
 import { ImportError } from './fileValidation'
 import { parsePowerState, num, isTruthy, str, buildScopeLabel, appendToMap, type ParsedRow } from './parserHelpers'
+import { analyzeStretchCluster } from './stretchClusterDetector'
 
 const REQUIRED = new Set(['vm_name', 'num_cpus'])
 
@@ -325,10 +326,66 @@ function aggregate(rows: VmRow[]): AggregateOutput {
   }
 }
 
+/**
+ * LiveOptics has no vSAN sheet — run the heuristic-only detector per scope.
+ * For each cluster name appearing in ≥2 datacenters, build hostCountByDc and
+ * let the analyzer decide. Scope-label keyword matches also fire.
+ */
+function applyStretchHeuristics(result: AggregateResult): void {
+  if (!result.rawByScope) return
+
+  const dcSetByClusterName = new Map<string, Set<string>>()
+  for (const key of result.rawByScope.keys()) {
+    const parts = key.split('||')
+    if (parts.length === 2) {
+      const [dc, cluster] = parts as [string, string]
+      if (cluster && cluster !== '__standalone__') {
+        const set = dcSetByClusterName.get(cluster) ?? new Set<string>()
+        set.add(dc)
+        dcSetByClusterName.set(cluster, set)
+      }
+    }
+  }
+
+  const globalSignals: string[] = []
+  let anyStretch = false
+  for (const [scopeKey, scope] of result.rawByScope.entries()) {
+    const parts = scopeKey.split('||')
+    const clusterName = parts.length === 2 ? parts[1]! : scopeKey
+    const dcSet = dcSetByClusterName.get(clusterName)
+
+    const hostCountByDc = dcSet && dcSet.size === 2
+      ? new Map(Array.from(dcSet).map((dc) => [dc, result.rawByScope!.get(`${dc}||${clusterName}`)?.existingServerCount ?? 0]))
+      : undefined
+
+    const analysis = analyzeStretchCluster({
+      scopeKey,
+      scopeLabel: result.scopeLabels?.[scopeKey] ?? scopeKey,
+      ...(hostCountByDc && { hostCountByDc }),
+    })
+
+    if (analysis.isStretchCluster) {
+      result.rawByScope.set(scopeKey, {
+        ...scope,
+        isStretchCluster: true,
+        stretchSignals: [...analysis.signals],
+      })
+      anyStretch = true
+      for (const s of analysis.signals) if (!globalSignals.includes(s)) globalSignals.push(s)
+    }
+  }
+
+  if (anyStretch) {
+    result.isStretchCluster = true
+    result.stretchSignals = globalSignals
+  }
+}
+
 export async function parseLiveoptics(
   buffer: ArrayBuffer,
   format: 'liveoptics-xlsx' | 'liveoptics-csv',
 ): Promise<Omit<ClusterImportResult, 'sourceFormat'>> {
-  if (format === 'liveoptics-xlsx') return parseXlsx(buffer)
-  return parseCsvBuffer(buffer)
+  const result = format === 'liveoptics-xlsx' ? await parseXlsx(buffer) : parseCsvBuffer(buffer)
+  applyStretchHeuristics(result)
+  return result
 }

--- a/src/lib/utils/import/rvtoolsParser.ts
+++ b/src/lib/utils/import/rvtoolsParser.ts
@@ -1,6 +1,7 @@
 import type { ClusterImportResult, ScopeData, VmRow as ScopedVmRow } from './index'
-import { RVTOOLS_ALIASES, RVTOOLS_VHOST_ALIASES, CLUSTER_ALIASES, DATACENTER_ALIASES, resolveColumns } from './columnResolver'
+import { RVTOOLS_ALIASES, RVTOOLS_VHOST_ALIASES, RVTOOLS_VSAN_ALIASES, CLUSTER_ALIASES, DATACENTER_ALIASES, resolveColumns } from './columnResolver'
 import { parsePowerState, num, isTruthy, str, buildScopeLabel, appendToMap, type ParsedRow } from './parserHelpers'
+import { analyzeStretchCluster } from './stretchClusterDetector'
 
 const REQUIRED = new Set(['vm_name', 'num_cpus'])
 
@@ -214,6 +215,81 @@ export async function parseRvtools(
         }
       }
     }
+  }
+
+  // vSAN sheet — explicit stretch signals (optional sheet)
+  const vSanSheet = wb.Sheets['vSAN']
+  const vsanByCluster = new Map<string, { stretched?: boolean; faultDomains: Set<string> }>()
+  if (vSanSheet) {
+    const vsanRows = XLSX.utils.sheet_to_json<VInfoRow>(vSanSheet, { defval: '' })
+    const firstVsan = vsanRows[0]
+    if (firstVsan) {
+      const vsanCols = resolveColumns(Object.keys(firstVsan), RVTOOLS_VSAN_ALIASES, new Set())
+      for (const row of vsanRows) {
+        const cluster = str(row, vsanCols['cluster_name'])
+        if (!cluster) continue
+        const entry = vsanByCluster.get(cluster) ?? { faultDomains: new Set<string>() }
+        const stretchedRaw = vsanCols['stretched'] ? str(row, vsanCols['stretched']) : ''
+        if (stretchedRaw && /^(true|yes|1|enabled)$/i.test(stretchedRaw.trim())) {
+          entry.stretched = true
+        }
+        const fd = vsanCols['fault_domain'] ? str(row, vsanCols['fault_domain']) : ''
+        if (fd) entry.faultDomains.add(fd)
+        vsanByCluster.set(cluster, entry)
+      }
+    }
+  }
+
+  // Build datacenter distribution per cluster name (heuristic fallback)
+  // Same cluster name seen in ≥2 DCs → candidate for stretched
+  const dcSetByClusterName = new Map<string, Set<string>>()
+  for (const key of scopeMap.keys()) {
+    const parts = key.split('||')
+    if (parts.length === 2) {
+      const [dc, cluster] = parts as [string, string]
+      if (cluster && cluster !== '__standalone__') {
+        const set = dcSetByClusterName.get(cluster) ?? new Set<string>()
+        set.add(dc)
+        dcSetByClusterName.set(cluster, set)
+      }
+    }
+  }
+
+  // Run detector per scope and write isStretchCluster / stretchSignals into rawByScope
+  const globalSignals: string[] = []
+  let anyStretch = false
+  for (const [scopeKey, scope] of rawByScope.entries()) {
+    const parts = scopeKey.split('||')
+    const clusterName = parts.length === 2 ? parts[1]! : scopeKey
+    const vsanEntry = vsanByCluster.get(clusterName)
+    const dcSet = dcSetByClusterName.get(clusterName)
+
+    const hostCountByDc = dcSet && dcSet.size === 2
+      ? new Map(Array.from(dcSet).map((dc) => [dc, rawByScope.get(`${dc}||${clusterName}`)?.existingServerCount ?? 0]))
+      : undefined
+
+    const analysis = analyzeStretchCluster({
+      scopeKey,
+      scopeLabel: scopeLabels[scopeKey] ?? scopeKey,
+      ...(vsanEntry?.stretched !== undefined && { explicitStretchFromVsan: vsanEntry.stretched }),
+      ...(vsanEntry && vsanEntry.faultDomains.size > 0 && { faultDomainCount: vsanEntry.faultDomains.size }),
+      ...(hostCountByDc && { hostCountByDc }),
+    })
+
+    if (analysis.isStretchCluster) {
+      rawByScope.set(scopeKey, {
+        ...scope,
+        isStretchCluster: true,
+        stretchSignals: [...analysis.signals],
+      })
+      anyStretch = true
+      for (const s of analysis.signals) if (!globalSignals.includes(s)) globalSignals.push(s)
+    }
+  }
+
+  if (anyStretch) {
+    result.isStretchCluster = true
+    result.stretchSignals = globalSignals
   }
 
   return result

--- a/src/lib/utils/import/scopeAggregator.ts
+++ b/src/lib/utils/import/scopeAggregator.ts
@@ -56,6 +56,10 @@ export function aggregateScopes(
   let cpuUtilServerCount = 0
   let ramUtilServerCount = 0
 
+  // Stretch: any selected scope being stretched poisons the aggregate (conservative).
+  let anyStretch = false
+  const stretchSignalsAcc: string[] = []
+
   for (const scope of selected) {
     totalVcpus += scope.totalVcpus
     totalVms += scope.totalVms
@@ -102,6 +106,15 @@ export function aggregateScopes(
       weightedRamUtilSum += scope.ramUtilizationPercent * scope.existingServerCount
       ramUtilServerCount += scope.existingServerCount
     }
+
+    if (scope.isStretchCluster === true) {
+      anyStretch = true
+      if (scope.stretchSignals) {
+        for (const s of scope.stretchSignals) {
+          if (!stretchSignalsAcc.includes(s)) stretchSignalsAcc.push(s)
+        }
+      }
+    }
   }
 
   const avgRamPerVmGb = totalVmCount > 0 ? weightedRamSum / totalVmCount : 0
@@ -144,5 +157,6 @@ export function aggregateScopes(
     vmCount: totalVmCount,
     warnings: allWarnings,
     ...esxFields,
+    ...(anyStretch && { isStretchCluster: true, stretchSignals: stretchSignalsAcc }),
   }
 }

--- a/src/lib/utils/import/stretchClusterDetector.ts
+++ b/src/lib/utils/import/stretchClusterDetector.ts
@@ -1,0 +1,81 @@
+/**
+ * Stretch cluster detection — pure, no I/O.
+ *
+ * Inputs are assembled by the parser (vSAN sheet probe when available, host
+ * distribution from vHost/ESX sheets, and the scope label string). Output is
+ * a verdict plus human-readable signals that feed the preview tooltip.
+ */
+
+export type StretchConfidence = 'high' | 'medium' | 'low';
+
+export interface StretchAnalysis {
+  readonly isStretchCluster: boolean;
+  readonly confidence: StretchConfidence;
+  readonly signals: readonly string[];
+}
+
+export interface StretchDetectorInput {
+  readonly scopeKey: string;
+  readonly scopeLabel: string;
+  /** Host counts grouped by datacenter / fault domain, when known. */
+  readonly hostCountByDc?: ReadonlyMap<string, number>;
+  /** Explicit flag from vSAN sheet "Stretched Cluster" column. */
+  readonly explicitStretchFromVsan?: boolean;
+  /** Number of distinct fault domains seen in the vSAN sheet for this cluster. */
+  readonly faultDomainCount?: number;
+}
+
+const NAME_KEYWORD_RE = /\b(stretch(ed)?|metro)\b/i;
+const SYMMETRY_TOLERANCE = 0.25;
+
+function isSymmetric(a: number, b: number): boolean {
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  if (hi === 0) return false;
+  return (hi - lo) / hi <= SYMMETRY_TOLERANCE;
+}
+
+/**
+ * Analyze a cluster for stretched topology signals.
+ *
+ * Priority:
+ *   1. Explicit vSAN signal (stretched column, or ≥2 fault domains).
+ *   2. Two DCs with symmetric host counts.
+ *   3. Name keyword match (stretch / stretched / metro).
+ * Anything else → low confidence, not stretched.
+ */
+export function analyzeStretchCluster(input: StretchDetectorInput): StretchAnalysis {
+  const signals: string[] = [];
+
+  if (input.explicitStretchFromVsan === true) {
+    signals.push('vSAN sheet marks cluster as stretched');
+    return { isStretchCluster: true, confidence: 'high', signals };
+  }
+
+  if (typeof input.faultDomainCount === 'number' && input.faultDomainCount >= 2) {
+    signals.push(`vSAN sheet lists ${input.faultDomainCount} fault domains`);
+    return { isStretchCluster: true, confidence: 'high', signals };
+  }
+
+  if (input.hostCountByDc && input.hostCountByDc.size === 2) {
+    const [a, b] = Array.from(input.hostCountByDc.values()) as [number, number];
+    if (isSymmetric(a, b)) {
+      const dcs = Array.from(input.hostCountByDc.keys()).join(' / ');
+      signals.push(`2 datacenters with symmetric host counts (${a} / ${b} across ${dcs})`);
+      const nameMatch = NAME_KEYWORD_RE.test(input.scopeLabel);
+      if (nameMatch) signals.push(`scope label "${input.scopeLabel}" contains stretch/metro keyword`);
+      return {
+        isStretchCluster: true,
+        confidence: nameMatch ? 'high' : 'medium',
+        signals,
+      };
+    }
+  }
+
+  if (NAME_KEYWORD_RE.test(input.scopeLabel)) {
+    signals.push(`scope label "${input.scopeLabel}" contains stretch/metro keyword`);
+    return { isStretchCluster: true, confidence: 'medium', signals };
+  }
+
+  return { isStretchCluster: false, confidence: 'low', signals };
+}

--- a/src/schemas/currentClusterSchema.ts
+++ b/src/schemas/currentClusterSchema.ts
@@ -69,6 +69,7 @@ export const currentClusterSchema = z.object({
   cpuUtilizationPercent: optionalPercent,
   ramUtilizationPercent: optionalPercent,
   cpuFrequencyGhz: optionalPositiveNumber,
+  isStretchCluster: z.boolean().optional(),
 });
 
 export type CurrentClusterInput = z.infer<typeof currentClusterSchema>;

--- a/src/store/useImportStore.ts
+++ b/src/store/useImportStore.ts
@@ -78,6 +78,7 @@ export const useImportStore = create<ImportState>((set, get) => ({
       ...(aggregate.avgRamPerVmGb != null && { avgRamPerVmGb: aggregate.avgRamPerVmGb }),
       ...(aggregate.cpuModel != null && { cpuModel: aggregate.cpuModel }),
       ...(aggregate.cpuFrequencyGhz != null && { cpuFrequencyGhz: aggregate.cpuFrequencyGhz }),
+      ...(aggregate.isStretchCluster != null && { isStretchCluster: aggregate.isStretchCluster }),
     }
     useClusterStore.getState().setCurrentCluster(cluster)
   },

--- a/src/types/cluster.ts
+++ b/src/types/cluster.ts
@@ -19,6 +19,7 @@ export interface OldCluster {
   readonly avgRamPerVmGb?: number;          // average RAM per VM (GB) — seeds Step 2 scenario defaults
   readonly cpuFrequencyGhz?: number;        // avg CPU clock frequency in GHz — required for GHz sizing mode
   readonly cpuModel?: string;               // display-only CPU model string extracted from import (e.g. "Xeon Gold 6526Y")
+  readonly isStretchCluster?: boolean;      // stretched topology — each site must carry the full workload on failure
 }
 
 /**

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -30,4 +30,8 @@ export interface ScenarioResult {
   readonly cpuUtilizationPercent: number;
   readonly ramUtilizationPercent: number;
   readonly diskUtilizationPercent: number;
+  /** True when stretch-cluster doubling was applied (cluster.isStretchCluster === true) */
+  readonly stretchApplied: boolean;
+  /** Server count after stretch doubling + even-rounding, before HA reserve. Undefined when not applied. */
+  readonly stretchPairedCount?: number;
 }

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -8,8 +8,9 @@ export type LimitingResource = 'cpu' | 'ram' | 'disk' | 'specint' | 'ghz';
  * The computed output from a sizing calculation for a given OldCluster + Scenario pair.
  * All fields are readonly — this object is never mutated after creation (Object.freeze).
  *
- * CALC-05: finalCount = max(cpuLimitedCount, ramLimitedCount, diskLimitedCount)
- * CALC-04: finalCount = rawCount + haReserveCount (0, 1, or 2)
+ * CALC-05: rawCount = max(cpuLimitedCount, ramLimitedCount, diskLimitedCount)
+ * CALC-STRETCH: when isStretchCluster, effectiveRaw = rawCount * 2 (site symmetry)
+ * CALC-04: finalCount = max(effectiveRaw + haReserveCount, minServerCount ?? 0)
  * CALC-06: utilization metrics derived from finalCount
  */
 export interface ScenarioResult {


### PR DESCRIPTION
Adds stretch/metro cluster detection during RVTools and LiveOptics imports by analyzing scope labels, host count symmetry, and site or datacenter distribution. Surfaces detection signals in the import preview modal and doubles the server count in sizing constraints when a stretch topology is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for stretched cluster topologies with a UI toggle and exportable configuration.

* **Improvements**
  * Automatic stretch-cluster detection during imports with informational signals and a confirmation step in the preview.
  * Server sizing now accounts for stretched topologies and displays paired-count breakdowns in sizing rows.
  * Import parsing accepts additional column variants and ensures stretch info is preserved in exported JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->