### PR TITLE
fix(sizing): vCPU density-cap honesty + per-site stretch HA reserve

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -5,19 +5,26 @@ Client-side-only static web app for presales engineers to size refreshed server 
 
 ## Tech Stack
 - **Framework:** React 19 + TypeScript strict (Vite 8 for build)
-- **UI:** Tailwind v4 + shadcn/ui (base-ui primitives) + Recharts 2.15 + Sonner (toast)
-- **State:** Zustand v5 (5 stores: cluster, scenarios, wizard, theme, import) + localStorage persistence + URL hash sharing
+- **UI:** Tailwind v4 + shadcn/ui (base-ui primitives) + **ECharts 6** (recharts fully removed) + Sonner (toast)
+- **i18n:** i18next + react-i18next + i18next-browser-languagedetector
+- **State:** Zustand v5 (**6 stores**: cluster, scenarios, wizard, theme, import, exclusions) + localStorage persistence + URL hash sharing
 - **Import:** xlsx@0.18.5 (locked MIT — do NOT upgrade) + jszip
 - **Export:** jsPDF + jspdf-autotable + pptxgenjs (all lazy-loaded)
-- **Testing:** Vitest + React Testing Library (596 tests)
+- **Testing:** Vitest + React Testing Library (~796 test cases across 73 test files)
+- **Lint/format:** Biome (`biome.json`) — replaces ESLint. Run as `npx biome check .` (NOT `rtk lint`, which mis-parses Biome output). a11y rules are `warn`.
 - **Deployment:** GitHub Pages via GitHub Actions
 
-## Current Version: v2.2 (596 tests, 26 phases shipped)
+## Current State (2026-06)
+- On `main`. "Precision Cockpit" UI look-and-feel shipped (drag-and-drop import dropzone, dark-mode fixes, disaggregated layout default).
+- Simplification roadmap sub-projects: A + D (biome) done; C (ECharts migration) done; E (i18n) done; B (visual/PPTX) largely landed via Precision Cockpit.
+- package.json version is `0.0.0` (not a meaningful release tag).
 
 ## Key Architecture Patterns
 - **Derive-on-read:** `useScenariosResults` and `useVsanBreakdowns` hooks compute on render, never stored in Zustand
-- **Sizing formulas centralized:** `src/lib/sizing/` (formulas.ts, constraints.ts, vsanFormulas.ts, vsanBreakdown.ts, vsanConstants.ts)
-- **Import parsers:** `src/lib/utils/import/` (liveopticParser, rvtoolsParser, jsonParser, columnResolver, scopeAggregator)
+- **Sizing formulas centralized:** `src/lib/sizing/` (formulas.ts, constraints.ts, display.ts, defaults.ts, clusterTotals.ts, clusterReadiness.ts, vsanFormulas.ts, vsanBreakdown.ts, vsanConstants.ts, chartColors.ts, chartOptions/)
+  - vCPU mode = pure assignment-density cap; CPU utilization does NOT affect the count (only the CALC-06 output metric). RAM utilization DOES right-size the RAM count.
+  - Stretch cluster: workload doubled (`stretchPairedCount = rawCount × 2`); HA reserve is per-site → `finalCount = (rawCount + haReserve) × 2`.
+- **Import parsers:** `src/lib/utils/import/` (liveopticParser, rvtoolsParser, jsonParser, columnResolver, scopeAggregator, fileValidation)
 - **External URLs:** centralized in `src/lib/config.ts`
 - **Scope keys:** format `dc||cluster` or `dc||__standalone__` for clusterless hosts
 
@@ -25,7 +32,7 @@ Client-side-only static web app for presales engineers to size refreshed server 
 ```
 src/
   components/
-    step1/     # CurrentClusterForm, FileImportButton, ImportPreviewModal, ScopeBadge, DerivedMetricsPanel
+    step1/     # CurrentClusterForm, FileImportButton/dropzone, ImportPreviewModal, ScopeBadge, DerivedMetricsPanel
     step2/     # ScenarioCard, ScenarioResults, VsanGrowthSection
     step3/     # ComparisonTable, SizingChart, CoreCountChart, CapacityStackedChart, MinNodesChart, Step3ReviewExport
     wizard/    # WizardShell, StepIndicator, SizingModeToggle, ThemeToggle
@@ -33,13 +40,16 @@ src/
     ui/        # shadcn/ui components
   hooks/       # useScenariosResults, useVsanBreakdowns, useSpecLookup
   lib/
-    sizing/    # formulas, constraints, vsan*, display, defaults, chartColors
+    sizing/    # formulas, constraints, display, defaults, vsan*, chartColors, chartOptions/
     utils/     # export, clipboard, persistence, downloadChartPng, chartCapture, exportPdf, exportPptx, specLookup, logoDataUrl, config
       import/  # parsers, columnResolver, scopeAggregator, fileValidation
-  store/       # useClusterStore, useScenariosStore, useWizardStore, useThemeStore, useImportStore
+  store/       # useClusterStore, useScenariosStore, useWizardStore, useThemeStore, useImportStore, useExclusionsStore
   schemas/     # Zod schemas (currentCluster, scenario, session)
   types/       # cluster.ts, results.ts, breakdown.ts
 ```
+
+## Knowledge Graph
+This repo has a `code-review-graph` MCP knowledge graph — prefer it (semantic_search_nodes, query_graph, get_impact_radius, detect_changes) over Grep/Glob for structural exploration.
 
 ## Companion Project
 - **spec-search** (fjacquet/spec-search): SPEC CPU2017 benchmark explorer. GitHub Pages serves per-processor JSON files used by Presizion for auto-lookup.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -31,7 +31,8 @@ project_name: "cluster-sizer"
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages: []
+languages:
+  - typescript
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings

--- a/src/components/step2/ScenarioResults.tsx
+++ b/src/components/step2/ScenarioResults.tsx
@@ -49,9 +49,6 @@ export function ScenarioResults({ scenarioId }: ScenarioResultsProps) {
     growthPercent: scenario.growthPercent,
     targetVcpuToPCoreRatio: scenario.targetVcpuToPCoreRatio,
     coresPerServer,
-    ...(currentCluster.cpuUtilizationPercent !== undefined && {
-      cpuUtilizationPercent: currentCluster.cpuUtilizationPercent,
-    }),
   });
 
   const effectiveVmCount = currentCluster.totalVms;

--- a/src/lib/sizing/__tests__/constraints.test.ts
+++ b/src/lib/sizing/__tests__/constraints.test.ts
@@ -740,12 +740,13 @@ describe('computeScenarioResult — stretch cluster', () => {
     expect(result.requiredCount).toBe(24);
   });
 
-  it('stretch + haReserveCount=1 adds the reserve on top of the paired count', () => {
+  it('stretch + haReserveCount=1 applies the reserve per-site (doubled): (rawCount + 1) × 2', () => {
     const stretchedCluster = { ...CPU_LIMITED_CLUSTER, isStretchCluster: true };
     const stretchedScenario = { ...CPU_LIMITED_SCENARIO, haReserveCount: 1 as const };
     const result = computeScenarioResult(stretchedCluster, stretchedScenario);
-    expect(result.stretchPairedCount).toBe(48);
-    expect(result.finalCount).toBe(49);
+    // workload doubling is reserve-independent; reserve is one spare host per site
+    expect(result.stretchPairedCount).toBe(48); // rawCount(24) × 2
+    expect(result.finalCount).toBe(50); // (24 + 1) × 2
     expect(result.haReserveApplied).toBe(true);
   });
 

--- a/src/lib/sizing/__tests__/display.test.ts
+++ b/src/lib/sizing/__tests__/display.test.ts
@@ -6,6 +6,7 @@
  * Conversion to multiplicative factor (1 + percent/100) is internal to display module.
  */
 import { describe, expect, it } from 'vitest';
+import { computeScenarioResult } from '../constraints';
 import {
   cpuFormulaString,
   diskFormulaString,
@@ -247,21 +248,8 @@ describe('Growth annotations (GROW-04)', () => {
   });
 });
 
-describe('cpuFormulaString with utilization (UTIL-03 display)', () => {
-  it('includes utilization factor when cpuUtilizationPercent is not 100: ceil(2000 × 70% × 120% / 4 / 48)', () => {
-    const result = cpuFormulaString({
-      totalVcpus: 2000,
-      growthPercent: 0,
-      safetyPercent: 20,
-      targetVcpuToPCoreRatio: 4,
-      coresPerServer: 48,
-      cpuUtilizationPercent: 70,
-    });
-    expect(result).toContain('70%');
-    expect(result).toContain('ceil');
-    expect(result).toContain('2000');
-  });
-  it('omits utilization factor when cpuUtilizationPercent is absent', () => {
+describe('cpuFormulaString — pure density cap (no utilization factor)', () => {
+  it('never renders a utilization factor: ceil(2000 × 120% / 4 / 48)', () => {
     const result = cpuFormulaString({
       totalVcpus: 2000,
       growthPercent: 0,
@@ -269,7 +257,60 @@ describe('cpuFormulaString with utilization (UTIL-03 display)', () => {
       targetVcpuToPCoreRatio: 4,
       coresPerServer: 48,
     });
-    // Should not contain a separate utilization percentage (only the headroom)
     expect(result).toBe('ceil(2000 × 120% / 4 / 48)');
+  });
+});
+
+// Regression: the displayed CPU formula must equal the number it sits next to.
+// Evaluates the rendered string's arithmetic for the growth=0 case and compares
+// it to computeScenarioResult's cpuLimitedCount. Before the fix, util≠100 made
+// the string evaluate to a different (smaller) number than the count shown.
+describe('cpuFormulaString — displayed value equals computed count (regression)', () => {
+  function evalCpuFormula(s: string): number {
+    // "ceil(3200 × 120% / 4 / 40)" -> 3200 * 1.20 / 4 / 40 -> Math.ceil
+    const inner = s.replace(/^ceil\(/, '').replace(/\)$/, '');
+    const parts = inner.split(' / ');
+    const factorPart = parts[0] ?? '';
+    const divisors = parts.slice(1);
+    const pieces = factorPart.split(' × ').map((p) => p.trim());
+    let value = Number(pieces[0]);
+    for (const p of pieces.slice(1)) {
+      const pct = p.match(/^([\d.]+)%$/);
+      if (pct) value *= Number(pct[1]) / 100;
+    }
+    for (const d of divisors) value /= Number(d);
+    return Math.ceil(value);
+  }
+
+  it('util≠100, growth=0: rendered CPU formula evaluates to cpuLimitedCount', () => {
+    const cluster = {
+      totalVcpus: 3200,
+      totalVms: 100,
+      totalPcores: 800,
+      cpuUtilizationPercent: 10,
+    };
+    const scenario = {
+      id: '00000000-0000-0000-0000-000000000001',
+      name: 'CPU-Limited',
+      socketsPerServer: 2,
+      coresPerSocket: 20,
+      ramPerServerGb: 1024,
+      diskPerServerGb: 50000,
+      targetVcpuToPCoreRatio: 4,
+      ramPerVmGb: 2,
+      diskPerVmGb: 10,
+      growthPercent: 0,
+      safetyPercent: 20,
+      haReserveCount: 0 as const,
+    };
+    const result = computeScenarioResult(cluster, scenario);
+    const formula = cpuFormulaString({
+      totalVcpus: cluster.totalVcpus,
+      safetyPercent: scenario.safetyPercent,
+      growthPercent: scenario.growthPercent,
+      targetVcpuToPCoreRatio: scenario.targetVcpuToPCoreRatio,
+      coresPerServer: scenario.socketsPerServer * scenario.coresPerSocket,
+    });
+    expect(evalCpuFormula(formula)).toBe(result.cpuLimitedCount); // 24, not 3
   });
 });

--- a/src/lib/sizing/constraints.ts
+++ b/src/lib/sizing/constraints.ts
@@ -188,21 +188,22 @@ export function computeScenarioResult(
   // CALC-05: Raw count is the maximum of all active constraints
   const rawCount = Math.max(cpuLimitedCount, ramLimitedCount, diskLimitedCount);
 
-  // CALC-STRETCH: stretched topology — each site must carry the full workload,
-  // so the raw count is doubled for site symmetry. Stretch provides site-level
-  // fault tolerance; any explicit haReserveCount set by the user adds on top
-  // (belt-and-suspenders) but is not implied.
+  // CALC-STRETCH + CALC-04: stretched topology — each site carries the full
+  // workload, so the workload is doubled for site symmetry (stretchPairedCount).
+  // The HA reserve is a PER-SITE intent ("N+1 local"): in a stretch cluster it
+  // applies to each site independently, so it is doubled along with the workload
+  // (N+1 local → +2 total). Non-stretch clusters add the reserve once.
   const stretchApplied = cluster.isStretchCluster === true;
-  let effectiveRaw = rawCount;
-  let stretchPairedCount: number | undefined;
-  if (stretchApplied) {
-    effectiveRaw = rawCount * 2;
-    stretchPairedCount = effectiveRaw;
-  }
-
-  // CALC-04: HA reserve — add 0, 1, or 2 servers after the constraint max
   const haReserveCount = scenario.haReserveCount ?? 0;
-  const withHA = effectiveRaw + haReserveCount;
+
+  let stretchPairedCount: number | undefined;
+  let withHA: number;
+  if (stretchApplied) {
+    stretchPairedCount = rawCount * 2; // doubled workload (reserve-independent)
+    withHA = (rawCount + haReserveCount) * 2; // one spare host per site
+  } else {
+    withHA = rawCount + haReserveCount;
+  }
 
   // Pin floor: finalCount is never less than minServerCount when set
   const finalCount =

--- a/src/lib/sizing/display.ts
+++ b/src/lib/sizing/display.ts
@@ -16,7 +16,6 @@ export interface CpuFormulaParams {
   readonly safetyPercent: number;
   readonly targetVcpuToPCoreRatio: number;
   readonly coresPerServer: number;
-  readonly cpuUtilizationPercent?: number;
   readonly growthPercent?: number;
 }
 
@@ -46,28 +45,21 @@ export interface SpecintFormulaParams {
 
 /**
  * Returns a human-readable formula string for the CPU-limited server count (CALC-01).
- * When cpuUtilizationPercent is provided and not 100, includes utilization factor.
  *
- * Format without utilization: ceil(totalVcpus × headroom% / ratio / coresPerServer)
- * Format with utilization:    ceil(totalVcpus × utilPct% × headroom% / ratio / coresPerServer)
+ * vCPU sizing is a pure assignment-density cap: the count never depends on observed
+ * CPU utilization (a parked VM still consumes its vCPU assignment). Utilization is
+ * therefore NOT rendered here — doing so previously produced a formula string that
+ * evaluated to a different number than the count shown beside it. Observed CPU % is
+ * surfaced separately as a result output metric (CALC-06), not inside this formula.
  *
- * Example (no util): "ceil(2000 × 120% / 4 / 48)"
- * Example (with util): "ceil(2000 × 70% × 120% / 4 / 48)"
+ * Format: ceil(totalVcpus × headroom% [× +growth% growth] / ratio / coresPerServer)
+ * Example: "ceil(2000 × 120% / 4 / 48)"
  */
 export function cpuFormulaString(params: CpuFormulaParams): string {
-  const {
-    totalVcpus,
-    safetyPercent,
-    targetVcpuToPCoreRatio,
-    coresPerServer,
-    cpuUtilizationPercent,
-    growthPercent,
-  } = params;
+  const { totalVcpus, safetyPercent, targetVcpuToPCoreRatio, coresPerServer, growthPercent } =
+    params;
   const headroomDisplay = `${100 + safetyPercent}%`;
   const growthSuffix = (growthPercent ?? 0) !== 0 ? ` × +${growthPercent}% growth` : '';
-  if (cpuUtilizationPercent !== undefined && cpuUtilizationPercent !== 100) {
-    return `ceil(${totalVcpus} × ${cpuUtilizationPercent}% × ${headroomDisplay}${growthSuffix} / ${targetVcpuToPCoreRatio} / ${coresPerServer})`;
-  }
   return `ceil(${totalVcpus} × ${headroomDisplay}${growthSuffix} / ${targetVcpuToPCoreRatio} / ${coresPerServer})`;
 }
 


### PR DESCRIPTION
## Summary

Three sizing-correctness fixes surfaced while reviewing how vCPU sizing is presented and how stretch clusters reserve for HA, plus a Serena project-config refresh.

### 1. vCPU CPU formula is a pure density cap
The displayed CPU formula previously injected `× util%` (e.g. `ceil(362 × 10% × 120% / 4 / 32)`) while the result shown was `4` — the string evaluated to `1`, not `4`. vCPU sizing is a hard assignment-density cap; observed CPU utilization never affects the count (a parked VM still consumes its vCPU assignment). The spurious factor is removed from the display so the formula now actually evaluates to the number beside it. Compute and the CALC-06 utilization **output metric** are unchanged. Removing `cpuUtilizationPercent` from `CpuFormulaParams` makes `tsc` structurally reject the bad call site.

### 2. Stretch HA reserve is per-site
Previously `finalCount = rawCount × 2 + haReserve` (`2N + 1`). The reserve is a per-site intent — "N+1 local" means one spare host **per site** — so it is now doubled with the workload: `finalCount = (rawCount + haReserve) × 2` (`2N + 2`). `stretchPairedCount` stays the doubled workload (`rawCount × 2`). Mode-agnostic.

### 3. Serena config
Refreshed the stale `project_overview` memory (ECharts 6, i18n, 6 stores, ~796 tests, current sizing semantics) and set `languages: [typescript]` so symbol tools work.

## Design & plan docs
- `docs/superpowers/specs/2026-06-01-vcpu-density-cap-stretch-ha-design.md`
- `docs/superpowers/plans/2026-06-01-vcpu-density-cap-stretch-ha.md`

## Test plan
- [x] Full suite: **800 pass / 0 fail**
- [x] `tsc -b` clean
- [x] `npm run build` succeeds
- [x] Biome: no new issues on changed files

## Follow-up (not in this PR)
Confirmed gap: the app never validates that a proposed server can host the cluster's **largest single VM** (no `largestVmVcpus`/`largestVmRamGb` captured, no fit check). Needs its own brainstorm → spec → plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)