### PR TITLE
feat: biggest-VM feasibility check (non-blocking single-VM fit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.10.0] -- 2026-06-01
+
+### Added
+
+- **Biggest-VM feasibility check**: a non-blocking, two-tier warning when the cluster's largest single VM — by vCPU or by RAM, independently — cannot fit on one proposed target host. The largest VM (by vCPU and by RAM) is captured at import (RVTools / LiveOptics per-VM rows) and aggregated as the max across selected scopes; manual entry has no per-VM data, so the check is silently skipped (`unknown`).
+  - **vCPU fit** vs the host's physical cores (`sockets × cores/socket`): `ok` ≤ cores, `warn` ≤ cores × SMT(2) (relies on SMT / spans NUMA), `fail` > logical CPUs.
+  - **RAM fit** vs usable (vSAN-aware) and nameplate RAM: `ok` ≤ usable, `warn` ≤ nameplate, `fail` > nameplate.
+  - Surfaced as an amber (`warn`) / red (`fail`) per-scenario banner in Step 2 and a largest-VM info line in the Step 1 import preview. Always non-blocking — never gates advancing or export. The vCPU:pCore ratio (an aggregate consolidation cap) is deliberately not used for single-VM fit. Localized in en / fr / de / it.
+
+## [2.9.1] -- 2026-06-01
+
+### Fixed
+
+- **vCPU formula is a pure density cap**: removed a spurious `× util%` factor from the displayed CPU formula so the string evaluates to the result shown beside it. vCPU sizing is a hard assignment-density cap; observed CPU utilization never affects the count. Compute and the achieved-CPU-% output metric are unchanged.
+- **Stretch HA reserve is now per-site**: a stretch cluster now computes `(rawCount + haReserve) × 2` (`2N + 2`) instead of `rawCount × 2 + haReserve` (`2N + 1`), since "N+1 local" means one spare host per site. The doubled-workload figure (`stretchPairedCount`) is unchanged.
+
+### Internal
+
+- Refreshed Serena project memory; enabled the TypeScript language server.
+
 ## [2.9.0] -- 2026-06-01
 
 ### Added

--- a/docs/superpowers/plans/2026-06-01-biggest-vm-feasibility.md
+++ b/docs/superpowers/plans/2026-06-01-biggest-vm-feasibility.md
@@ -1,0 +1,998 @@
+# Biggest-VM Feasibility Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Warn (non-blocking) when a refreshed cluster's single largest VM — by vCPU or by RAM — cannot fit on one proposed target host.
+
+**Architecture:** Capture the per-scope largest-VM vCPU/RAM at import (RVTools/LiveOptics only), persist it on `OldCluster`, assess fit in a pure helper (`src/lib/sizing/singleVmFit.ts`), embed the verdict in `ScenarioResult`, and surface it as a presentational amber/red banner in Step 2 plus an info line in the Step 1 import preview. Manual entry has no per-VM data → verdict `unknown` → check silently skipped.
+
+**Tech Stack:** React 19 + TypeScript strict, Zustand, Zod, Vitest + React Testing Library, react-i18next (en/fr/de/it), Biome.
+
+**Source spec:** `docs/superpowers/specs/2026-06-01-biggest-vm-feasibility-design.md`
+
+---
+
+## Key facts verified against the codebase (read before starting)
+
+- `OldCluster` (`src/types/cluster.ts:7-23`) holds **aggregates only**; all extra fields are `readonly … ?`.
+- `Scenario` (`src/types/cluster.ts:29-56`) has `socketsPerServer`, `coresPerSocket`, `ramPerServerGb`, and optional vSAN fields. **There is no `coresPerServer` field** — compute it as `socketsPerServer × coresPerSocket`.
+- vSAN "applies" iff `scenario.vsanFttPolicy !== undefined`.
+- `computeVsanEffectiveRamPerNode(ramPerNodeGb: number, vsanMemoryPerHostGb?: number): number` lives in `src/lib/sizing/vsanFormulas.ts:136-141` and returns `Math.max(0, ramPerNodeGb - vsanMemoryPerHostGb)` (default overhead 6 GiB). It takes **numbers, not a Scenario**.
+- `VmRow` (`src/lib/utils/import/index.ts:3-10`) has required `vcpus: number` and `ramMib: number`.
+- `ScopeData = Omit<ClusterImportResult, 'sourceFormat'|'detectedScopes'|'scopeLabels'|'rawByScope'|'vmRowsByScope'>` (`index.ts:12-15`). Adding optional fields to `ClusterImportResult` makes them appear on `ScopeData` automatically.
+- Both parsers use a named `interface ScopeAccum { totalVcpus; totalMemMib; totalDiskMib; vmCount }` (rvtools `:29-34`, liveoptics `:25-30`) and a `scopeMap` of it.
+- `aggregateScopes` (`src/lib/utils/import/scopeAggregator.ts:15-178`) sums/averages fields; largest-VM must use **MAX** across selected scopes.
+- Session persistence validates `cluster` against `currentClusterSchema` (`src/schemas/currentClusterSchema.ts:52-66`), which **strips fields not in the schema**. New fields MUST be added there to round-trip through localStorage/session.
+- `jsonParser.ts:40-63` maps JSON→`OldCluster` with conditional spreads; add the new fields there for JSON import round-trip.
+- `ImportPreviewModal.handleApply` (`src/components/step1/ImportPreviewModal.tsx:113-165`) builds the cluster from `previewCluster: ScopeData` with conditional spreads.
+- `useScenariosResults` (`src/hooks/useScenariosResults.ts`) maps every scenario through `computeScenarioResult`, so a new `ScenarioResult` field reaches all consumers with no extra wiring.
+- i18n: one JSON file per locale per namespace at `src/i18n/locales/{en,fr,de,it}/{step1,step2}.json`; key-parity test at `src/i18n/__tests__/keyParity.test.ts` fails if any locale is missing a key. Interpolation syntax is `{{var}}`.
+- No existing test compares a whole `ScenarioResult` via `toEqual`/`toMatchObject`/snapshot — adding `singleVmFit` breaks nothing.
+
+## File Structure
+
+**Create**
+
+- `src/lib/sizing/singleVmFit.ts` — pure feasibility helper + `FitVerdict`/`SingleVmFit` types + `SMT_THREADS_PER_CORE`.
+- `src/lib/sizing/__tests__/singleVmFit.test.ts` — unit tests for the helper.
+
+**Modify**
+
+- `src/lib/utils/import/index.ts` — add `largestVmVcpus?`/`largestVmRamMib?` to `ClusterImportResult`.
+- `src/lib/utils/import/rvtoolsParser.ts` — track per-scope largest VM in `ScopeAccum`, emit on `ScopeData`.
+- `src/lib/utils/import/liveopticParser.ts` — same.
+- `src/lib/utils/import/scopeAggregator.ts` — MAX largest-VM across scopes.
+- `src/types/cluster.ts` — add `largestVmVcpus?`/`largestVmRamGb?` to `OldCluster`.
+- `src/schemas/currentClusterSchema.ts` — add the two fields so they persist.
+- `src/lib/utils/import/jsonParser.ts` — map the two fields on JSON import.
+- `src/components/step1/ImportPreviewModal.tsx` — capture into cluster (MiB→GiB) + render info line.
+- `src/types/results.ts` — add `readonly singleVmFit: SingleVmFit;`.
+- `src/lib/sizing/constraints.ts` — call helper, include in result.
+- `src/components/step2/ScenarioResults.tsx` — render amber/red banner.
+- `src/i18n/locales/{en,fr,de,it}/step1.json` — `importPreview.largestVm`.
+- `src/i18n/locales/{en,fr,de,it}/step2.json` — `singleVmFit.*` keys.
+
+**Test (modify/add)**
+
+- `src/lib/utils/import/__tests__/rvtoolsParser.test.ts` (or existing parser test) — largest-VM capture.
+- `src/lib/utils/import/__tests__/scopeAggregator.test.ts` — MAX across scopes.
+- `src/lib/sizing/__tests__/constraints.test.ts` — result includes correct `singleVmFit`.
+- `src/components/step2/__tests__/ScenarioResults.test.tsx` (new or existing) — banner rendering.
+- `src/components/step1/__tests__/ImportPreviewModal.test.tsx` — info line rendering.
+
+---
+
+## Task 1: Capture largest VM per scope in the import parsers
+
+**Files:**
+- Modify: `src/lib/utils/import/index.ts:17-44` (ClusterImportResult)
+- Modify: `src/lib/utils/import/rvtoolsParser.ts:29-34, 96-156, 164-175`
+- Modify: `src/lib/utils/import/liveopticParser.ts:25-30, 290-367`
+- Test: `src/lib/utils/import/__tests__/rvtoolsParser.test.ts` (existing) and `liveopticParser.test.ts` (existing)
+
+- [ ] **Step 1: Write a failing parser test (RVTools)**
+
+Add to `src/lib/utils/import/__tests__/rvtoolsParser.test.ts` (match the existing import/build style in that file; it parses a small in-memory workbook/rows fixture):
+
+```ts
+it('captures the largest single VM by vCPU and by RAM (MiB) per scope', () => {
+  // Two VMs in one cluster: VM-A is the vCPU monster, VM-B is the RAM monster.
+  const result = parseRvtools(
+    buildWorkbook([
+      { VM: 'VM-A', 'CPUs': 32, 'Memory': 65536, 'Provisioned MiB': 100, Cluster: 'CL-1', Datacenter: 'DC1' },
+      { VM: 'VM-B', 'CPUs': 8, 'Memory': 524288, 'Provisioned MiB': 100, Cluster: 'CL-1', Datacenter: 'DC1' },
+    ]),
+  );
+  const scope = result.rawByScope?.get('DC1||CL-1');
+  expect(scope?.largestVmVcpus).toBe(32);
+  expect(scope?.largestVmRamMib).toBe(524288);
+});
+```
+
+> If the existing test file uses a different fixture builder (e.g. `makeSheet`, raw `rows` arrays), mirror that exact helper — do not invent `buildWorkbook`. The assertions on `largestVmVcpus`/`largestVmRamMib` are the part that matters.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/rvtoolsParser.test.ts`
+Expected: FAIL — `largestVmVcpus`/`largestVmRamMib` are `undefined` (property does not exist on `ScopeData`).
+
+- [ ] **Step 3: Add the fields to `ClusterImportResult`**
+
+In `src/lib/utils/import/index.ts`, inside `interface ClusterImportResult` (after `isStretchCluster?: boolean;` / near the other optional metric fields), add:
+
+```ts
+  /** Largest single VM by vCPU count across this scope's VM rows (import only). */
+  largestVmVcpus?: number;
+  /** Largest single VM by RAM in MiB across this scope's VM rows (import only). */
+  largestVmRamMib?: number;
+```
+
+(`ScopeData` inherits both automatically — they are not in the `Omit` list.)
+
+- [ ] **Step 4: Track largest VM in the RVTools `ScopeAccum`**
+
+In `src/lib/utils/import/rvtoolsParser.ts`, extend the accumulator interface (`:29-34`):
+
+```ts
+interface ScopeAccum {
+  totalVcpus: number;
+  totalMemMib: number;
+  totalDiskMib: number;
+  vmCount: number;
+  largestVcpus: number;
+  largestMemMib: number;
+}
+```
+
+Update the per-row accumulation (`:143-148` default and `:149-...` set). Replace the `const existing = scopeMap.get(scopeKey) ?? {...}` default and the `scopeMap.set(scopeKey, {...})` call with:
+
+```ts
+    const existing = scopeMap.get(scopeKey) ?? {
+      totalVcpus: 0,
+      totalMemMib: 0,
+      totalDiskMib: 0,
+      vmCount: 0,
+      largestVcpus: 0,
+      largestMemMib: 0,
+    };
+    scopeMap.set(scopeKey, {
+      totalVcpus: existing.totalVcpus + cpus,
+      totalMemMib: existing.totalMemMib + mem,
+      totalDiskMib: existing.totalDiskMib + disk,
+      vmCount: existing.vmCount + 1,
+      largestVcpus: Math.max(existing.largestVcpus, cpus),
+      largestMemMib: Math.max(existing.largestMemMib, mem),
+    });
+```
+
+Then in the per-scope `rawByScope.set(key, {...})` block (`:164-175`), add the two fields to the emitted `ScopeData`:
+
+```ts
+    rawByScope.set(key, {
+      totalVcpus: accum.totalVcpus,
+      totalVms: accum.vmCount,
+      totalDiskGb: Math.round((accum.totalDiskMib / 1024) * 10) / 10,
+      avgRamPerVmGb:
+        accum.vmCount > 0 ? Math.round((accum.totalMemMib / accum.vmCount / 1024) * 10) / 10 : 0,
+      vmCount: accum.vmCount,
+      warnings: [],
+      largestVmVcpus: accum.largestVcpus,
+      largestVmRamMib: accum.largestMemMib,
+    });
+```
+
+- [ ] **Step 5: Run the RVTools test to verify it passes**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/rvtoolsParser.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Write the same failing test for LiveOptics**
+
+Add the equivalent test to `src/lib/utils/import/__tests__/liveopticParser.test.ts`, using that file's existing fixture style, asserting `scope?.largestVmVcpus` and `scope?.largestVmRamMib`.
+
+- [ ] **Step 7: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/liveopticParser.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 8: Apply the identical change to the LiveOptics parser**
+
+In `src/lib/utils/import/liveopticParser.ts`, extend `ScopeAccum` (`:25-30`) with `largestVcpus: number;` and `largestMemMib: number;`. Update the accumulator default (`:335-340`) and `scopeMap.set` (`:341-...`) and the per-scope `rawByScope.set` (`:356-367`) exactly as in Step 4 (same field names, `cpus`/`mem` are the same locals here).
+
+- [ ] **Step 9: Run the LiveOptics test to verify it passes**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/liveopticParser.test.ts`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+rtk git add src/lib/utils/import/index.ts src/lib/utils/import/rvtoolsParser.ts src/lib/utils/import/liveopticParser.ts src/lib/utils/import/__tests__/rvtoolsParser.test.ts src/lib/utils/import/__tests__/liveopticParser.test.ts
+rtk git commit -m "feat(import): capture largest single VM (vCPU + RAM MiB) per scope"
+```
+
+---
+
+## Task 2: Aggregate largest VM as the MAX across selected scopes
+
+**Files:**
+- Modify: `src/lib/utils/import/scopeAggregator.ts:15-178`
+- Test: `src/lib/utils/import/__tests__/scopeAggregator.test.ts` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/utils/import/__tests__/scopeAggregator.test.ts` (mirror the existing fixture/`aggregateScopes` call style in that file):
+
+```ts
+it('takes the MAX largest-VM vCPU and RAM across selected scopes (not the sum)', () => {
+  const rawByScope = new Map<string, ScopeData>([
+    ['A', { totalVcpus: 10, totalVms: 5, totalDiskGb: 0, avgRamPerVmGb: 4, vmCount: 5, warnings: [], largestVmVcpus: 16, largestVmRamMib: 32768 }],
+    ['B', { totalVcpus: 10, totalVms: 5, totalDiskGb: 0, avgRamPerVmGb: 4, vmCount: 5, warnings: [], largestVmVcpus: 48, largestVmRamMib: 16384 }],
+  ]);
+  const agg = aggregateScopes(rawByScope, ['A', 'B']);
+  expect(agg.largestVmVcpus).toBe(48); // max, not 64
+  expect(agg.largestVmRamMib).toBe(32768); // max, not 49152
+});
+
+it('omits largest-VM fields when no selected scope has them', () => {
+  const rawByScope = new Map<string, ScopeData>([
+    ['A', { totalVcpus: 10, totalVms: 5, totalDiskGb: 0, avgRamPerVmGb: 4, vmCount: 5, warnings: [] }],
+  ]);
+  const agg = aggregateScopes(rawByScope, ['A']);
+  expect(agg.largestVmVcpus).toBeUndefined();
+  expect(agg.largestVmRamMib).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/scopeAggregator.test.ts`
+Expected: FAIL — `agg.largestVmVcpus` is `undefined`.
+
+- [ ] **Step 3: Accumulate the MAX in `aggregateScopes`**
+
+In `src/lib/utils/import/scopeAggregator.ts`, declare accumulators alongside the other locals (near `let anyStretch = false;`):
+
+```ts
+  let maxLargestVmVcpus: number | undefined;
+  let maxLargestVmRamMib: number | undefined;
+```
+
+Inside the `for (const scope of selected)` loop, before the `if (scope.isStretchCluster === true)` block, add:
+
+```ts
+    if (scope.largestVmVcpus !== undefined) {
+      maxLargestVmVcpus = Math.max(maxLargestVmVcpus ?? 0, scope.largestVmVcpus);
+    }
+    if (scope.largestVmRamMib !== undefined) {
+      maxLargestVmRamMib = Math.max(maxLargestVmRamMib ?? 0, scope.largestVmRamMib);
+    }
+```
+
+Add them to the `esxFields` partial (after the existing representative-field assignments), so they round-trip through the spread on return:
+
+```ts
+  if (maxLargestVmVcpus !== undefined) esxFields.largestVmVcpus = maxLargestVmVcpus;
+  if (maxLargestVmRamMib !== undefined) esxFields.largestVmRamMib = maxLargestVmRamMib;
+```
+
+(`esxFields` is `Partial<ScopeData>`, which now includes both fields, and is spread into the returned object via `...esxFields`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/utils/import/__tests__/scopeAggregator.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/lib/utils/import/scopeAggregator.ts src/lib/utils/import/__tests__/scopeAggregator.test.ts
+rtk git commit -m "feat(import): aggregate largest-VM vCPU/RAM as max across scopes"
+```
+
+---
+
+## Task 3: Persist largest VM on `OldCluster` (type, schema, JSON, import apply)
+
+**Files:**
+- Modify: `src/types/cluster.ts:7-23`
+- Modify: `src/schemas/currentClusterSchema.ts:52-66`
+- Modify: `src/lib/utils/import/jsonParser.ts:40-63`
+- Modify: `src/components/step1/ImportPreviewModal.tsx:113-165`
+- Test: `src/schemas/__tests__/schemas.test.ts` (existing)
+
+- [ ] **Step 1: Write the failing schema round-trip test**
+
+Add to `src/schemas/__tests__/schemas.test.ts`, inside the `describe('currentClusterSchema', …)` area:
+
+```ts
+it('parses and preserves largestVmVcpus and largestVmRamGb', () => {
+  const result = currentClusterSchema.parse({
+    totalVcpus: 100,
+    totalPcores: 50,
+    totalVms: 20,
+    largestVmVcpus: 48,
+    largestVmRamGb: 512,
+  });
+  expect(result.largestVmVcpus).toBe(48);
+  expect(result.largestVmRamGb).toBe(512);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/schemas/__tests__/schemas.test.ts`
+Expected: FAIL — Zod strips the unknown fields, so both are `undefined`.
+
+- [ ] **Step 3: Add the fields to `OldCluster`**
+
+In `src/types/cluster.ts`, inside `interface OldCluster` (after `isStretchCluster?: boolean;`):
+
+```ts
+  readonly largestVmVcpus?: number; // largest single VM by vCPU (import only) — single-VM fit check
+  readonly largestVmRamGb?: number; // largest single VM by RAM in GiB (import only) — single-VM fit check
+```
+
+- [ ] **Step 4: Add the fields to the Zod schema**
+
+In `src/schemas/currentClusterSchema.ts`, inside `currentClusterSchema = z.object({ … })` (after `isStretchCluster: z.boolean().optional(),`):
+
+```ts
+  largestVmVcpus: optionalNonNegativeNumber,
+  largestVmRamGb: optionalNonNegativeNumber,
+```
+
+- [ ] **Step 5: Run the schema test to verify it passes**
+
+Run: `npx vitest run src/schemas/__tests__/schemas.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Map the fields on JSON import**
+
+In `src/lib/utils/import/jsonParser.ts`, inside the `const cluster: OldCluster = { … }` object (after the `isStretchCluster` spread, `:40-63`):
+
+```ts
+  ...(c.largestVmVcpus != null && { largestVmVcpus: num(c.largestVmVcpus, 'largestVmVcpus') }),
+  ...(c.largestVmRamGb != null && { largestVmRamGb: num(c.largestVmRamGb, 'largestVmRamGb') }),
+```
+
+- [ ] **Step 7: Capture the fields in `ImportPreviewModal.handleApply` (MiB→GiB for RAM)**
+
+In `src/components/step1/ImportPreviewModal.tsx`, in the non-JSON branch of `handleApply`, inside the `const cluster = { … }` object (after the `isStretchCluster` spread, `:155-156`):
+
+```ts
+      ...(previewCluster.largestVmVcpus != null && {
+        largestVmVcpus: previewCluster.largestVmVcpus,
+      }),
+      ...(previewCluster.largestVmRamMib != null && {
+        largestVmRamGb: Math.round((previewCluster.largestVmRamMib / 1024) * 10) / 10,
+      }),
+```
+
+- [ ] **Step 8: Run the full import + schema suites to verify nothing regressed**
+
+Run: `npx vitest run src/schemas src/lib/utils/import`
+Expected: PASS (all green).
+
+- [ ] **Step 9: Commit**
+
+```bash
+rtk git add src/types/cluster.ts src/schemas/currentClusterSchema.ts src/lib/utils/import/jsonParser.ts src/components/step1/ImportPreviewModal.tsx src/schemas/__tests__/schemas.test.ts
+rtk git commit -m "feat(cluster): persist largest-VM vCPU/RAM on OldCluster (schema, json, import apply)"
+```
+
+---
+
+## Task 4: Pure feasibility helper `singleVmFit.ts`
+
+**Files:**
+- Create: `src/lib/sizing/singleVmFit.ts`
+- Test: `src/lib/sizing/__tests__/singleVmFit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/sizing/__tests__/singleVmFit.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { OldCluster, Scenario } from '../../../types/cluster';
+import { createDefaultScenario } from '../defaults';
+import { assessSingleVmFit, SMT_THREADS_PER_CORE } from '../singleVmFit';
+
+// Host: 2 sockets x 16 cores = 32 cores, 64 logical (SMT 2), 512 GiB nameplate, no vSAN.
+const HOST: Scenario = {
+  ...createDefaultScenario(),
+  socketsPerServer: 2,
+  coresPerSocket: 16,
+  ramPerServerGb: 512,
+};
+
+function clusterWith(largestVmVcpus?: number, largestVmRamGb?: number): OldCluster {
+  return {
+    totalVcpus: 0,
+    totalPcores: 0,
+    totalVms: 0,
+    ...(largestVmVcpus !== undefined && { largestVmVcpus }),
+    ...(largestVmRamGb !== undefined && { largestVmRamGb }),
+  };
+}
+
+describe('SMT_THREADS_PER_CORE', () => {
+  it('is 2 (x86 standard)', () => {
+    expect(SMT_THREADS_PER_CORE).toBe(2);
+  });
+});
+
+describe('assessSingleVmFit — vCPU dimension', () => {
+  it('ok when largest vCPU <= physical cores', () => {
+    expect(assessSingleVmFit(clusterWith(32, 8), HOST).vcpu).toBe('ok');
+  });
+  it('warn when largest vCPU is between cores and logical CPUs (relies on SMT)', () => {
+    expect(assessSingleVmFit(clusterWith(48, 8), HOST).vcpu).toBe('warn');
+  });
+  it('fail when largest vCPU exceeds logical CPUs', () => {
+    expect(assessSingleVmFit(clusterWith(96, 8), HOST).vcpu).toBe('fail');
+  });
+  it('unknown when no largest-vCPU data', () => {
+    expect(assessSingleVmFit(clusterWith(undefined, 8), HOST).vcpu).toBe('unknown');
+  });
+});
+
+describe('assessSingleVmFit — RAM dimension', () => {
+  it('ok when largest RAM <= usable (no vSAN → usable === nameplate)', () => {
+    expect(assessSingleVmFit(clusterWith(8, 512), HOST).ram).toBe('ok');
+  });
+  it('fail when largest RAM exceeds nameplate', () => {
+    expect(assessSingleVmFit(clusterWith(8, 768), HOST).ram).toBe('fail');
+  });
+  it('warn when largest RAM is between usable and nameplate (vSAN overhead)', () => {
+    // vSAN on: usable = 512 - 6 = 506 GiB; 510 GiB is > usable but <= nameplate.
+    const vsanHost: Scenario = { ...HOST, vsanFttPolicy: 'raid1-ftt1', vsanMemoryPerHostGb: 6 };
+    expect(assessSingleVmFit(clusterWith(8, 510), vsanHost).ram).toBe('warn');
+    expect(assessSingleVmFit(clusterWith(8, 510), vsanHost).usableRamGb).toBe(506);
+  });
+  it('unknown when no largest-RAM data', () => {
+    expect(assessSingleVmFit(clusterWith(8, undefined), HOST).ram).toBe('unknown');
+  });
+});
+
+describe('assessSingleVmFit — overall', () => {
+  it('overall is the worst of the two known dimensions', () => {
+    const fit = assessSingleVmFit(clusterWith(48, 768), HOST); // vcpu=warn, ram=fail
+    expect(fit.overall).toBe('fail');
+  });
+  it('overall ignores an unknown dimension', () => {
+    const fit = assessSingleVmFit(clusterWith(48, undefined), HOST); // vcpu=warn, ram=unknown
+    expect(fit.overall).toBe('warn');
+  });
+  it('overall is unknown when both dimensions are unknown', () => {
+    const fit = assessSingleVmFit(clusterWith(undefined, undefined), HOST);
+    expect(fit.overall).toBe('unknown');
+  });
+  it('echoes the host geometry and largest-VM numbers for UI copy', () => {
+    const fit = assessSingleVmFit(clusterWith(48, 256), HOST);
+    expect(fit.coresPerServer).toBe(32);
+    expect(fit.logicalCpus).toBe(64);
+    expect(fit.largestVmVcpus).toBe(48);
+    expect(fit.largestVmRamGb).toBe(256);
+  });
+});
+```
+
+> If `'raid1-ftt1'` is not a valid `VsanFttPolicy` literal, substitute any real member of that union (see `src/lib/sizing/vsanConstants.ts`). The only requirement is that `vsanFttPolicy` is defined so the vSAN path is taken.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/sizing/__tests__/singleVmFit.test.ts`
+Expected: FAIL — module `../singleVmFit` does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/lib/sizing/singleVmFit.ts`:
+
+```ts
+import type { OldCluster, Scenario } from '../../types/cluster';
+import { computeVsanEffectiveRamPerNode } from './vsanFormulas';
+
+export type FitVerdict = 'ok' | 'warn' | 'fail' | 'unknown';
+
+export interface SingleVmFit {
+  vcpu: FitVerdict;
+  ram: FitVerdict;
+  /** Worst of vcpu/ram; an `unknown` dimension is ignored unless both are unknown. */
+  overall: FitVerdict;
+  largestVmVcpus?: number; // echoed for UI copy
+  largestVmRamGb?: number;
+  coresPerServer: number; // sockets x cores/socket
+  logicalCpus: number; // coresPerServer x SMT_THREADS_PER_CORE
+  usableRamGb: number; // vSAN-aware
+}
+
+/** x86 standard 2 threads/core. YAGNI to make configurable now. */
+export const SMT_THREADS_PER_CORE = 2;
+
+const RANK: Record<FitVerdict, number> = { unknown: -1, ok: 0, warn: 1, fail: 2 };
+
+function assessVcpu(largest: number | undefined, cores: number, logical: number): FitVerdict {
+  if (largest === undefined) return 'unknown';
+  if (largest <= cores) return 'ok';
+  if (largest <= logical) return 'warn';
+  return 'fail';
+}
+
+function assessRam(largest: number | undefined, usable: number, nameplate: number): FitVerdict {
+  if (largest === undefined) return 'unknown';
+  if (largest <= usable) return 'ok';
+  if (largest <= nameplate) return 'warn';
+  return 'fail';
+}
+
+function worstVerdict(a: FitVerdict, b: FitVerdict): FitVerdict {
+  const known = [a, b].filter((v): v is Exclude<FitVerdict, 'unknown'> => v !== 'unknown');
+  if (known.length === 0) return 'unknown';
+  return known.reduce((worst, v) => (RANK[v] > RANK[worst] ? v : worst));
+}
+
+/**
+ * Non-blocking single-VM fit check: can the cluster's largest VM (by vCPU and by
+ * RAM, independently) fit on ONE proposed target host? Pure; never divides — only
+ * compares — so degenerate host configs (cores=0/RAM=0) compare cleanly.
+ */
+export function assessSingleVmFit(cluster: OldCluster, scenario: Scenario): SingleVmFit {
+  const coresPerServer = scenario.socketsPerServer * scenario.coresPerSocket;
+  const logicalCpus = coresPerServer * SMT_THREADS_PER_CORE;
+  const vsanApplies = scenario.vsanFttPolicy !== undefined;
+  const usableRamGb = vsanApplies
+    ? computeVsanEffectiveRamPerNode(scenario.ramPerServerGb, scenario.vsanMemoryPerHostGb)
+    : scenario.ramPerServerGb;
+
+  const vcpu = assessVcpu(cluster.largestVmVcpus, coresPerServer, logicalCpus);
+  const ram = assessRam(cluster.largestVmRamGb, usableRamGb, scenario.ramPerServerGb);
+
+  return {
+    vcpu,
+    ram,
+    overall: worstVerdict(vcpu, ram),
+    ...(cluster.largestVmVcpus !== undefined && { largestVmVcpus: cluster.largestVmVcpus }),
+    ...(cluster.largestVmRamGb !== undefined && { largestVmRamGb: cluster.largestVmRamGb }),
+    coresPerServer,
+    logicalCpus,
+    usableRamGb,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/sizing/__tests__/singleVmFit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/lib/sizing/singleVmFit.ts src/lib/sizing/__tests__/singleVmFit.test.ts
+rtk git commit -m "feat(sizing): add pure single-VM fit helper (vCPU + RAM, vSAN-aware)"
+```
+
+---
+
+## Task 5: Embed `singleVmFit` in `ScenarioResult`
+
+**Files:**
+- Modify: `src/types/results.ts:16-38`
+- Modify: `src/lib/sizing/constraints.ts:1-15, 82-87, 241-258`
+- Test: `src/lib/sizing/__tests__/constraints.test.ts` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/sizing/__tests__/constraints.test.ts` (reuse the existing exported fixtures `CPU_LIMITED_CLUSTER`/`CPU_LIMITED_SCENARIO`):
+
+```ts
+describe('computeScenarioResult — singleVmFit', () => {
+  it('includes a singleVmFit verdict on every result', () => {
+    const result = computeScenarioResult(CPU_LIMITED_CLUSTER, CPU_LIMITED_SCENARIO);
+    expect(result.singleVmFit).toBeDefined();
+    // CPU_LIMITED_CLUSTER has no largestVm* fields → both dimensions unknown.
+    expect(result.singleVmFit.overall).toBe('unknown');
+  });
+
+  it('flags a monster VM that exceeds the host', () => {
+    const cluster = { ...CPU_LIMITED_CLUSTER, largestVmVcpus: 999, largestVmRamGb: 99999 };
+    const result = computeScenarioResult(cluster, CPU_LIMITED_SCENARIO);
+    expect(result.singleVmFit.overall).toBe('fail');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/sizing/__tests__/constraints.test.ts`
+Expected: FAIL — `result.singleVmFit` is `undefined`.
+
+- [ ] **Step 3: Add the field to `ScenarioResult`**
+
+In `src/types/results.ts`, add the import at the top (with the other type imports):
+
+```ts
+import type { SingleVmFit } from '../lib/sizing/singleVmFit';
+```
+
+Inside `interface ScenarioResult` (after `stretchPairedCount?: number;`):
+
+```ts
+  /** Non-blocking single-VM feasibility verdict (largest VM vs one host). */
+  readonly singleVmFit: SingleVmFit;
+```
+
+- [ ] **Step 4: Populate it in `computeScenarioResult`**
+
+In `src/lib/sizing/constraints.ts`, add to the imports block (`:1-15`):
+
+```ts
+import { assessSingleVmFit } from './singleVmFit';
+```
+
+In the returned frozen object (`:241-258`), add a field (e.g. after `stretchApplied,` and before the conditional `stretchPairedCount` spread):
+
+```ts
+    singleVmFit: assessSingleVmFit(cluster, scenario),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/sizing/__tests__/constraints.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check the whole project (results flow through `useScenariosResults`)**
+
+Run: `npx tsc -b`
+Expected: clean (no errors). Confirms every `ScenarioResult` consumer still type-checks with the new required field.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/types/results.ts src/lib/sizing/constraints.ts src/lib/sizing/__tests__/constraints.test.ts
+rtk git commit -m "feat(sizing): embed singleVmFit verdict in ScenarioResult"
+```
+
+---
+
+## Task 6: i18n keys for the banner and the import preview line (en/fr/de/it)
+
+**Files:**
+- Modify: `src/i18n/locales/{en,fr,de,it}/step2.json`
+- Modify: `src/i18n/locales/{en,fr,de,it}/step1.json`
+- Test: `src/i18n/__tests__/keyParity.test.ts` (existing — must stay green)
+
+- [ ] **Step 1: Add the `singleVmFit` block to `en/step2.json`**
+
+In `src/i18n/locales/en/step2.json`, add a top-level `"singleVmFit"` object (sibling of `"results"`):
+
+```json
+  "singleVmFit": {
+    "titleWarn": "Largest VM is a tight fit",
+    "titleFail": "Largest VM does not fit one host",
+    "vcpuWarn": "Largest VM ({{vcpu}} vCPU) exceeds this host's {{cores}} physical cores — it would rely on SMT / span NUMA nodes ({{logical}} logical CPUs).",
+    "vcpuFail": "Largest VM ({{vcpu}} vCPU) exceeds this host's {{logical}} logical CPUs — it cannot run on a single host.",
+    "ramWarn": "Largest VM needs {{ram}} GiB RAM; host offers {{usable}} GiB usable (of {{nameplate}} GiB) — fits nameplate but not after overhead.",
+    "ramFail": "Largest VM needs {{ram}} GiB RAM; host offers only {{nameplate}} GiB — it cannot run on a single host."
+  }
+```
+
+- [ ] **Step 2: Add the `importPreview.largestVm` key to `en/step1.json`**
+
+In `src/i18n/locales/en/step1.json`, inside the existing `"importPreview"` object:
+
+```json
+    "largestVm": "Largest VM: {{vcpu}} vCPU / {{ram}} GiB"
+```
+
+(Add a comma after the preceding entry as needed to keep valid JSON.)
+
+- [ ] **Step 3: Mirror both additions into fr/de/it**
+
+Add the same key paths with translated values. Use these (review for tone, but keys must match exactly):
+
+`fr/step2.json` → `singleVmFit`:
+```json
+  "singleVmFit": {
+    "titleWarn": "La plus grande VM tient tout juste",
+    "titleFail": "La plus grande VM ne tient pas sur un hôte",
+    "vcpuWarn": "La plus grande VM ({{vcpu}} vCPU) dépasse les {{cores}} cœurs physiques de cet hôte — elle reposerait sur le SMT / s'étendrait sur plusieurs nœuds NUMA ({{logical}} CPU logiques).",
+    "vcpuFail": "La plus grande VM ({{vcpu}} vCPU) dépasse les {{logical}} CPU logiques de cet hôte — elle ne peut pas tenir sur un seul hôte.",
+    "ramWarn": "La plus grande VM nécessite {{ram}} Gio de RAM ; l'hôte offre {{usable}} Gio utilisables (sur {{nameplate}} Gio) — tient sur la capacité nominale mais pas après surcharge.",
+    "ramFail": "La plus grande VM nécessite {{ram}} Gio de RAM ; l'hôte n'offre que {{nameplate}} Gio — elle ne peut pas tenir sur un seul hôte."
+  }
+```
+`fr/step1.json` → `importPreview.largestVm`: `"Plus grande VM : {{vcpu}} vCPU / {{ram}} Gio"`
+
+`de/step2.json` → `singleVmFit`:
+```json
+  "singleVmFit": {
+    "titleWarn": "Größte VM passt nur knapp",
+    "titleFail": "Größte VM passt nicht auf einen Host",
+    "vcpuWarn": "Größte VM ({{vcpu}} vCPU) übersteigt die {{cores}} physischen Kerne dieses Hosts — sie würde auf SMT angewiesen sein / NUMA-Knoten überspannen ({{logical}} logische CPUs).",
+    "vcpuFail": "Größte VM ({{vcpu}} vCPU) übersteigt die {{logical}} logischen CPUs dieses Hosts — sie kann nicht auf einem einzelnen Host laufen.",
+    "ramWarn": "Größte VM benötigt {{ram}} GiB RAM; Host bietet {{usable}} GiB nutzbar (von {{nameplate}} GiB) — passt auf Nennkapazität, aber nicht nach Overhead.",
+    "ramFail": "Größte VM benötigt {{ram}} GiB RAM; Host bietet nur {{nameplate}} GiB — sie kann nicht auf einem einzelnen Host laufen."
+  }
+```
+`de/step1.json` → `importPreview.largestVm`: `"Größte VM: {{vcpu}} vCPU / {{ram}} GiB"`
+
+`it/step2.json` → `singleVmFit`:
+```json
+  "singleVmFit": {
+    "titleWarn": "La VM più grande entra a malapena",
+    "titleFail": "La VM più grande non entra in un host",
+    "vcpuWarn": "La VM più grande ({{vcpu}} vCPU) supera i {{cores}} core fisici di questo host — si baserebbe su SMT / si estenderebbe su più nodi NUMA ({{logical}} CPU logiche).",
+    "vcpuFail": "La VM più grande ({{vcpu}} vCPU) supera le {{logical}} CPU logiche di questo host — non può funzionare su un singolo host.",
+    "ramWarn": "La VM più grande richiede {{ram}} GiB di RAM; l'host offre {{usable}} GiB utilizzabili (su {{nameplate}} GiB) — entra nella capacità nominale ma non dopo l'overhead.",
+    "ramFail": "La VM più grande richiede {{ram}} GiB di RAM; l'host offre solo {{nameplate}} GiB — non può funzionare su un singolo host."
+  }
+```
+`it/step1.json` → `importPreview.largestVm`: `"VM più grande: {{vcpu}} vCPU / {{ram}} GiB"`
+
+- [ ] **Step 4: Run the key-parity test**
+
+Run: `npx vitest run src/i18n/__tests__/keyParity.test.ts`
+Expected: PASS — all 4 locales have identical key sets for `step1` and `step2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/i18n/locales
+rtk git commit -m "feat(i18n): add single-VM fit + largest-VM keys (en/fr/de/it)"
+```
+
+---
+
+## Task 7: Step 2 banner in `ScenarioResults`
+
+**Files:**
+- Modify: `src/components/step2/ScenarioResults.tsx`
+- Test: `src/components/step2/__tests__/ScenarioResults.test.tsx` (add; the existing `ScenarioCard.test.tsx` already imports and renders `ScenarioResults` and mutates stores — mirror that setup)
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `src/components/step2/__tests__/ScenarioResults.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createDefaultScenario } from '@/lib/sizing/defaults';
+import { useClusterStore } from '@/store/useClusterStore';
+import { useScenariosStore } from '@/store/useScenariosStore';
+import { useWizardStore } from '@/store/useWizardStore';
+import { ScenarioResults } from '../ScenarioResults';
+
+// Host: 2 x 16 = 32 cores / 64 logical, 512 GiB.
+const scenario = { ...createDefaultScenario(), socketsPerServer: 2, coresPerSocket: 16, ramPerServerGb: 512 };
+
+beforeEach(() => {
+  useScenariosStore.setState({ scenarios: [scenario] });
+  useWizardStore.setState({ currentStep: 2, sizingMode: 'vcpu', layoutMode: 'hci' });
+});
+
+describe('ScenarioResults — single-VM fit banner', () => {
+  it('renders a fail callout when the largest VM cannot fit one host', () => {
+    useClusterStore.setState({
+      currentCluster: { totalVcpus: 100, totalPcores: 50, totalVms: 20, largestVmVcpus: 999 },
+    });
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.getByText(/cannot run on a single host/i)).toBeInTheDocument();
+  });
+
+  it('renders a warn banner when the largest VM relies on SMT', () => {
+    useClusterStore.setState({
+      currentCluster: { totalVcpus: 100, totalPcores: 50, totalVms: 20, largestVmVcpus: 48 },
+    });
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.getByText(/rely on SMT/i)).toBeInTheDocument();
+  });
+
+  it('renders no fit banner when the largest VM fits (ok)', () => {
+    useClusterStore.setState({
+      currentCluster: { totalVcpus: 100, totalPcores: 50, totalVms: 20, largestVmVcpus: 16, largestVmRamGb: 128 },
+    });
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.queryByText(/single host|rely on SMT/i)).not.toBeInTheDocument();
+  });
+
+  it('renders no fit banner for manual entry (unknown — no largest-VM data)', () => {
+    useClusterStore.setState({ currentCluster: { totalVcpus: 100, totalPcores: 50, totalVms: 20 } });
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.queryByText(/single host|rely on SMT/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+> Confirm the prop name `scenarioId` matches the actual `ScenarioResults` signature (it is read via `scenarios.findIndex((s) => s.id === scenarioId)` in the component). If the component instead reads the active scenario from the store, set that store state and drop the prop.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/components/step2/__tests__/ScenarioResults.test.tsx`
+Expected: FAIL — no fit banner rendered.
+
+- [ ] **Step 3: Add the presentational banner**
+
+In `src/components/step2/ScenarioResults.tsx`, after the existing results block (the `<div className="mt-4 p-4 …">` that renders server counts), and only when `result` is defined, render the banner. Add a small helper inside the component body that builds the message from `result.singleVmFit`, then the JSX:
+
+```tsx
+  const fit = result?.singleVmFit;
+  const showFit = fit !== undefined && (fit.overall === 'warn' || fit.overall === 'fail');
+
+  const fitTitle =
+    fit?.overall === 'fail' ? t('singleVmFit.titleFail') : t('singleVmFit.titleWarn');
+
+  const fitLines: string[] = [];
+  if (fit) {
+    if (fit.vcpu === 'warn') {
+      fitLines.push(
+        t('singleVmFit.vcpuWarn', { vcpu: fit.largestVmVcpus, cores: fit.coresPerServer, logical: fit.logicalCpus }),
+      );
+    } else if (fit.vcpu === 'fail') {
+      fitLines.push(t('singleVmFit.vcpuFail', { vcpu: fit.largestVmVcpus, logical: fit.logicalCpus }));
+    }
+    if (fit.ram === 'warn') {
+      fitLines.push(
+        t('singleVmFit.ramWarn', { ram: fit.largestVmRamGb, usable: fit.usableRamGb, nameplate: scenario?.ramPerServerGb }),
+      );
+    } else if (fit.ram === 'fail') {
+      fitLines.push(t('singleVmFit.ramFail', { ram: fit.largestVmRamGb, nameplate: scenario?.ramPerServerGb }));
+    }
+  }
+```
+
+JSX (place after the results `<div>`; `fail` uses the red `util-high` token, `warn` uses the amber pattern from `ImportPreviewModal:194`):
+
+```tsx
+      {showFit && (
+        <div
+          className={
+            fit?.overall === 'fail'
+              ? 'mt-3 flex flex-col gap-1 p-3 rounded border border-util-high/40 bg-util-high/10'
+              : 'mt-3 flex flex-col gap-1 p-3 rounded border border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20'
+          }
+          role="status"
+        >
+          <p className={fit?.overall === 'fail' ? 'text-sm font-medium text-util-high' : 'text-sm font-medium text-amber-700 dark:text-amber-300'}>
+            {fitTitle}
+          </p>
+          {fitLines.map((line) => (
+            <p key={line} className="text-sm text-foreground/80">
+              {line}
+            </p>
+          ))}
+        </div>
+      )}
+```
+
+No math lives in the component — all numbers come from `result.singleVmFit` (and `scenario.ramPerServerGb` for the nameplate echo).
+
+- [ ] **Step 4: Run the component test to verify it passes**
+
+Run: `npx vitest run src/components/step2/__tests__/ScenarioResults.test.tsx`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/components/step2/ScenarioResults.tsx src/components/step2/__tests__/ScenarioResults.test.tsx
+rtk git commit -m "feat(step2): non-blocking single-VM fit banner (amber warn / red fail)"
+```
+
+---
+
+## Task 8: Step 1 import-preview largest-VM info line
+
+**Files:**
+- Modify: `src/components/step1/ImportPreviewModal.tsx` (render block ~`:249-315`)
+- Test: `src/components/step1/__tests__/ImportPreviewModal.test.tsx` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/components/step1/__tests__/ImportPreviewModal.test.tsx`. The file mocks stores and `aggregateScopes`; use a single-scope `ScopeData`-style result so `previewCluster` is the result itself:
+
+```tsx
+describe('Largest-VM info line', () => {
+  const RESULT_WITH_LARGEST = {
+    totalVcpus: 100,
+    totalVms: 20,
+    totalDiskGb: 500,
+    avgRamPerVmGb: 8,
+    sourceFormat: 'rvtools' as const,
+    vmCount: 20,
+    warnings: [],
+    largestVmVcpus: 48,
+    largestVmRamMib: 262144, // 256 GiB
+  };
+
+  it('shows the largest-VM line (vCPU / GiB) when data is present', () => {
+    render(<ImportPreviewModal result={RESULT_WITH_LARGEST} {...defaultProps} />);
+    expect(screen.getByText(/Largest VM:\s*48 vCPU\s*\/\s*256 GiB/i)).toBeInTheDocument();
+  });
+
+  it('omits the largest-VM line when no per-VM data (manual-equivalent import)', () => {
+    const { largestVmVcpus: _v, largestVmRamMib: _r, ...withoutLargest } = RESULT_WITH_LARGEST;
+    render(<ImportPreviewModal result={withoutLargest} {...defaultProps} />);
+    expect(screen.queryByText(/Largest VM:/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+> Use the same `defaultProps` and render helper the existing tests in this file use. If `previewCluster` is only the aggregated value for multi-scope, this single-scope shape exercises the `result as ScopeData` branch — confirm against `ImportPreviewModal:104-107`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/components/step1/__tests__/ImportPreviewModal.test.tsx`
+Expected: FAIL — no "Largest VM:" text.
+
+- [ ] **Step 3: Render the info line**
+
+In `src/components/step1/ImportPreviewModal.tsx`, in the non-JSON preview info block (near the avg-RAM / pcores lines, ~`:265-273`), add — converting MiB→GiB for display, no stored math:
+
+```tsx
+            {previewCluster.largestVmVcpus != null && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">
+                  {t('importPreview.largestVm', {
+                    vcpu: previewCluster.largestVmVcpus,
+                    ram:
+                      previewCluster.largestVmRamMib != null
+                        ? Math.round((previewCluster.largestVmRamMib / 1024) * 10) / 10
+                        : 0,
+                  })}
+                </span>
+              </div>
+            )}
+```
+
+> Match the existing markup pattern for these info rows (the surrounding lines use a label/value `flex justify-between` row — copy that exact structure so styling is consistent). The `t` namespace here is `step1` (confirm via the component's `useTranslation('step1')` call).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/components/step1/__tests__/ImportPreviewModal.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/components/step1/ImportPreviewModal.tsx src/components/step1/__tests__/ImportPreviewModal.test.tsx
+rtk git commit -m "feat(step1): show largest-VM info line in import preview"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type-check**
+
+Run: `npx tsc -b`
+Expected: clean.
+
+- [ ] **Step 2: Lint + format**
+
+Run: `npx biome check .`
+Expected: no errors. (Per CLAUDE.md, do NOT use `rtk lint` for Biome — it mis-parses the output. If autofixable, run `npx biome check --write .` then re-run.)
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npx vitest run`
+Expected: all green (757 existing + the new tests).
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: succeeds (`tsc -b && vite build`).
+
+- [ ] **Step 5: Final commit (only if Step 2 auto-fixed formatting)**
+
+```bash
+rtk git add -A
+rtk git commit -m "chore: biome format for single-VM fit feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (every spec section maps to a task):
+
+- Capture `ScopeData.largestVmVcpus/largestVmRamMib` in both parsers → Task 1.
+- `aggregateScopes` takes the MAX (not sum) → Task 2.
+- `OldCluster.largestVmVcpus?/largestVmRamGb?`, populated in `handleApply` (MiB→GiB), round-trip via schema + jsonParser → Task 3.
+- Pure helper `singleVmFit.ts` with exact thresholds, vSAN-aware `usableRamGb`, `overall` precedence, both-unknown case → Task 4 (+ its tests).
+- `ScenarioResult.singleVmFit` + `computeScenarioResult` integration; flows through `useScenariosResults` automatically → Task 5.
+- i18n keys in 4 locales, parity test green → Task 6.
+- Step 2 amber/red non-blocking banner, `ok`/`unknown` render nothing, copy from numbers via i18n → Task 7.
+- Step 1 import-preview largest-VM line, shown only when present → Task 8.
+- Edge cases: manual/old-JSON → `unknown` (Task 4 tests + Task 7/8 absence tests); degenerate host (cores=0/RAM=0) handled by pure comparison, no division (Task 4 helper); vSAN-off → `usableRamGb = ramPerServerGb` (Task 4 helper).
+- Tests + `tsc`/`vitest`/`biome`/`build` gates → Tasks 1-8 inline + Task 9.
+
+**Out of scope (not planned, per spec):** configurable SMT, per-NUMA fit, Step 3/PPTX surfacing, manual-entry largest-VM capture.
+
+**Type consistency:** `FitVerdict`/`SingleVmFit`/`SMT_THREADS_PER_CORE`/`assessSingleVmFit` defined in Task 4 are used verbatim in Tasks 5/7. `largestVmVcpus`/`largestVmRamMib` (MiB, import layer) vs `largestVmVcpus`/`largestVmRamGb` (GiB, `OldCluster`) — the MiB→GiB conversion happens exactly once, in `handleApply` (Task 3) and in the Step 1 display (Task 8); the helper and banner only ever see GiB. `coresPerServer = socketsPerServer × coresPerSocket` computed once, in the helper.
+
+**Placeholder scan:** every code step contains complete code; the only `>` notes are guard-rails telling the engineer to match an existing fixture/prop name they must confirm by reading the target file — not deferred implementation.

--- a/docs/superpowers/specs/2026-06-01-biggest-vm-feasibility-design.md
+++ b/docs/superpowers/specs/2026-06-01-biggest-vm-feasibility-design.md
@@ -1,0 +1,161 @@
+# Biggest-VM Feasibility Check — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (brainstorm); to be planned
+**Milestone:** post-v2.9.0
+
+## Context
+
+Presizion sizes a refreshed cluster from aggregate metrics (total vCPUs, total
+VMs, average RAM/VM, …) but never checks that the cluster's **largest single
+VM** can actually fit on **one** proposed host. `OldCluster` stores only
+aggregates, and no constraint validates single-VM fit. So the app can silently
+recommend, e.g., a 384 GiB host when a monster VM needs 512 GiB, or a host with
+fewer logical CPUs than a VM's vCPU count — a real sizing error a presales
+engineer would be embarrassed to ship in a customer deck.
+
+This adds a **non-blocking, two-tier feasibility check**: capture the biggest VM
+(by vCPU and by RAM) at import, and warn per-scenario when the proposed host
+can't host it. The vCPU:pCore ratio is an *aggregate* consolidation cap and is
+deliberately **not** used for single-VM fit.
+
+## Decisions (locked in brainstorm)
+
+- **Behavior:** always non-blocking. **Two tiers** — amber (`warn`) and red
+  (`fail`, still non-blocking). Never gate advancing/export.
+- **vCPU fit** (vs `coresPerServer = sockets × cores/socket`):
+  `ok` ≤ cores · `warn` ≤ cores × SMT(2) · `fail` > cores × SMT(2).
+- **RAM fit** (usable = nameplate − vSAN/host overhead):
+  `ok` ≤ usable · `warn` ≤ nameplate `ramPerServerGb` · `fail` > nameplate.
+- **Data source:** captured at **import only** (RVTools/LiveOptics per-VM rows).
+  Manual entry has no per-VM data → verdict `unknown` → check silently skipped.
+- **Surfacing:** per-scenario banner in Step 2 `ScenarioResults` + a largest-VM
+  info line in the Step 1 import preview.
+- **Architecture (Approach A):** pure helper in `src/lib/sizing/`, verdict
+  embedded in `ScenarioResult`, UI purely presentational.
+
+The largest-vCPU VM and largest-RAM VM may be **different VMs** — that is
+correct: the two host dimensions are independent, so the worst case per
+dimension is what must fit.
+
+## Units
+
+`VmRow.ramMib` is MiB; convert to GiB (`/1024`) for `largestVmRamGb`, consistent
+with how `avgRamPerVmGb` is derived. `ramPerServerGb` is treated as GiB
+throughout (matching existing usage). UI labels use "GiB".
+
+## Components & data flow
+
+### 1. Capture (import → model)
+
+- **`VmRow`** already carries `vcpus` and `ramMib` (`src/lib/utils/import/index.ts`).
+- **`ScopeData`**: add `largestVmVcpus: number` and `largestVmRamMib: number`.
+  Both parsers (`rvtoolsParser.ts`, `liveopticParser.ts`) compute these as the
+  per-scope max while iterating VM rows (same loop that builds `vmRowsByScope`).
+- **`aggregateScopes`** (`scopeAggregator.ts`): when combining selected scopes,
+  take the **max** of `largestVmVcpus` / `largestVmRamMib` across them (not sum).
+- **`OldCluster`** (`src/types/cluster.ts`): add optional
+  `largestVmVcpus?: number` and `largestVmRamGb?: number`. Populated in
+  `ImportPreviewModal.handleApply` from `previewCluster` (MiB→GiB for RAM).
+  Persist in the session/JSON export like other optional cluster fields
+  (round-trips through `persistence.ts` / `jsonParser.ts` automatically as plain
+  numeric fields). Absent for manual entry and JSON-without-the-fields (v-compat:
+  older JSON simply lacks them → `unknown`).
+
+### 2. Feasibility helper (pure)
+
+`src/lib/sizing/singleVmFit.ts`:
+
+```ts
+export type FitVerdict = 'ok' | 'warn' | 'fail' | 'unknown';
+
+export interface SingleVmFit {
+  vcpu: FitVerdict;
+  ram: FitVerdict;
+  overall: FitVerdict;        // worst of vcpu/ram; 'unknown' ignored unless both unknown
+  largestVmVcpus?: number;    // echoed for UI copy
+  largestVmRamGb?: number;
+  coresPerServer: number;
+  logicalCpus: number;        // coresPerServer × SMT_THREADS_PER_CORE
+  usableRamGb: number;        // vSAN-aware
+}
+
+export const SMT_THREADS_PER_CORE = 2; // x86 standard; YAGNI to make configurable now
+
+export function assessSingleVmFit(cluster: OldCluster, scenario: Scenario): SingleVmFit;
+```
+
+Thresholds exactly as in Decisions. `usableRamGb` = `computeVsanEffectiveRamPerNode(scenario)`
+when vSAN applies (HCI), else `scenario.ramPerServerGb`. `overall` precedence
+`ok < warn < fail`; a dimension that is `unknown` is ignored; if both dimensions
+are `unknown`, `overall = 'unknown'`.
+
+### 3. ScenarioResult integration
+
+- `src/types/results.ts`: add `readonly singleVmFit: SingleVmFit;`.
+- `computeScenarioResult` (`constraints.ts`): call `assessSingleVmFit(cluster, scenario)`
+  and include it in the returned result. No other result fields change.
+- `useScenariosResults` already maps cluster+scenario through `computeScenarioResult`,
+  so every consumer receives `singleVmFit` with no extra wiring.
+
+### 4. UI (presentational)
+
+- **`ScenarioResults.tsx`** (Step 2): when `singleVmFit.overall === 'warn'`
+  render an amber banner; `=== 'fail'` render a red (non-blocking) callout;
+  `ok`/`unknown` render nothing. Reuse the existing amber-banner styling pattern
+  (`border-amber-400/40 bg-amber-50/60 …`; red variant uses `util-high`). Copy is
+  built from `singleVmFit` numbers via i18n — no math in the component.
+- **`ImportPreviewModal.tsx`** (Step 1): info line `t('importPreview.largestVm', { vcpu, ram })`
+  shown when `previewCluster.largestVmVcpus` is present.
+
+### 5. i18n (en/fr/de/it, parity-tested)
+
+- `step2.singleVmFit`:
+  - `vcpuFail` / `vcpuWarn` — "Largest VM ({{vcpu}} vCPU) exceeds this host's
+    {{hostVcpu}} … " (warn: "relies on SMT / spans NUMA nodes").
+  - `ramFail` / `ramWarn` — "Largest VM needs {{ram}} GiB RAM; host offers
+    {{hostRamGb}} GiB usable …".
+  - Banner title/lead keys as needed (e.g. `titleWarn`, `titleFail`).
+- `step1.importPreview.largestVm` — "Largest VM: {{vcpu}} vCPU / {{ram}} GiB".
+
+## Error handling / edge cases
+
+- Missing per-VM data (manual, old JSON) → `unknown` → no banner, no info line.
+- Zero/degenerate host config (cores=0 or RAM=0) → treated as `fail` only when a
+  largest-VM value exists and exceeds it; otherwise `unknown`/`ok` (don't warn on
+  an unconfigured scenario). Helper must not divide; it only compares.
+- vSAN disabled / disaggregated → `usableRamGb = ramPerServerGb` (no overhead
+  subtraction beyond what `computeVsanEffectiveRamPerNode` already returns for the
+  non-vSAN path).
+
+## Testing
+
+- **`singleVmFit.test.ts`** — all tiers for vCPU and RAM (ok/warn/fail), `unknown`
+  when data absent, vSAN usable-RAM path, `overall = worst`, both-unknown case.
+- **Parser/aggregator tests** — per-scope `largestVmVcpus`/`largestVmRamMib`
+  captured; `aggregateScopes` returns the max across selected scopes (not sum).
+- **`computeScenarioResult`** — result includes a correct `singleVmFit`; update
+  existing full-object fixtures to include the new field.
+- **Components** — `ScenarioResults` renders amber for `warn`, red for `fail`,
+  nothing for `ok`/`unknown`; `ImportPreviewModal` shows the largest-VM line only
+  when data present.
+- Key-parity test stays green (new keys in all 4 locales).
+- `tsc -b` clean · full `vitest` green · `biome check` clean · `npm run build` ok.
+
+## Out of scope (follow-ups)
+
+- Making SMT threads-per-core a configurable scenario field.
+- Per-NUMA-node fit (vCPU/RAM per socket) beyond the cores-vs-logical heuristic.
+- Surfacing feasibility in the Step 3 review / PPTX export.
+- Capturing largest-VM for manual entry (no per-VM data exists there).
+
+## Self-review notes
+
+- **Placeholders:** none.
+- **Consistency:** units (MiB→GiB) stated once and applied in capture + helper +
+  UI; `usableRamGb` defined once and reused. Verdict precedence defined once.
+- **Scope:** single implementation plan — capture, one pure helper, one result
+  field, two UI touch-points, i18n, tests. No decomposition needed.
+- **Ambiguity:** "largest VM" = independent per-dimension maxima (explicit);
+  manual entry = `unknown` (explicit); ratio explicitly excluded from single-VM
+  fit.

--- a/src/components/step1/ImportPreviewModal.tsx
+++ b/src/components/step1/ImportPreviewModal.tsx
@@ -145,6 +145,12 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
         }),
         ...(previewCluster.isStretchCluster === true &&
           stretchConfirmed && { isStretchCluster: true }),
+        ...(previewCluster.largestVmVcpus != null && {
+          largestVmVcpus: previewCluster.largestVmVcpus,
+        }),
+        ...(previewCluster.largestVmRamMib != null && {
+          largestVmRamGb: Math.round((previewCluster.largestVmRamMib / 1024) * 10) / 10,
+        }),
       };
       setCurrentCluster(cluster);
       seedFromCluster(cluster);

--- a/src/components/step1/ImportPreviewModal.tsx
+++ b/src/components/step1/ImportPreviewModal.tsx
@@ -318,6 +318,19 @@ export function ImportPreviewModal({ result, open, onClose }: ImportPreviewModal
                 {result.ramUtilizationPercent}%
               </p>
             )}
+            {previewCluster.largestVmVcpus != null && (
+              <p>
+                <span className="font-medium">
+                  {t('importPreview.largestVm', {
+                    vcpu: previewCluster.largestVmVcpus,
+                    ram:
+                      previewCluster.largestVmRamMib != null
+                        ? Math.round((previewCluster.largestVmRamMib / 1024) * 10) / 10
+                        : 0,
+                  })}
+                </span>
+              </p>
+            )}
           </>
         )}
       </div>

--- a/src/components/step1/__tests__/ImportPreviewModal.test.tsx
+++ b/src/components/step1/__tests__/ImportPreviewModal.test.tsx
@@ -336,6 +336,31 @@ describe('ImportPreviewModal', () => {
     });
   });
 
+  describe('Largest-VM info line', () => {
+    const RESULT_WITH_LARGEST: ClusterImportResult = {
+      totalVcpus: 100,
+      totalVms: 20,
+      totalDiskGb: 500,
+      avgRamPerVmGb: 8,
+      sourceFormat: 'rvtools',
+      vmCount: 20,
+      warnings: [],
+      largestVmVcpus: 48,
+      largestVmRamMib: 262144, // 256 GiB
+    };
+
+    it('shows the largest-VM line (vCPU / GiB) when data is present', () => {
+      render(<ImportPreviewModal result={RESULT_WITH_LARGEST} {...defaultProps} />);
+      expect(screen.getByText(/Largest VM:\s*48 vCPU\s*\/\s*256 GiB/i)).toBeInTheDocument();
+    });
+
+    it('omits the largest-VM line when no per-VM data (manual-equivalent import)', () => {
+      const { largestVmVcpus: _v, largestVmRamMib: _r, ...withoutLargest } = RESULT_WITH_LARGEST;
+      render(<ImportPreviewModal result={withoutLargest} {...defaultProps} />);
+      expect(screen.queryByText(/Largest VM:/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('mobile drawer (FORM-04)', () => {
     it('renders Drawer with "Import Preview" title on mobile viewport', () => {
       mockMatchMedia(true);

--- a/src/components/step2/ScenarioResults.tsx
+++ b/src/components/step2/ScenarioResults.tsx
@@ -11,6 +11,7 @@ import { useClusterStore } from '@/store/useClusterStore';
 import { useScenariosStore } from '@/store/useScenariosStore';
 import { useWizardStore } from '@/store/useWizardStore';
 import type { LimitingResource } from '@/types/results';
+import { SingleVmFitBanner } from './SingleVmFitBanner';
 
 interface ScenarioResultsProps {
   scenarioId: string;
@@ -118,6 +119,7 @@ export function ScenarioResults({ scenarioId }: ScenarioResultsProps) {
           </div>
         </div>
       </div>
+      <SingleVmFitBanner fit={result.singleVmFit} nameplateRamGb={scenario.ramPerServerGb} />
     </div>
   );
 }

--- a/src/components/step2/SingleVmFitBanner.tsx
+++ b/src/components/step2/SingleVmFitBanner.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
+
+interface SingleVmFitBannerProps {
+  fit: SingleVmFit;
+  nameplateRamGb: number;
+}
+
+export function SingleVmFitBanner({ fit, nameplateRamGb }: SingleVmFitBannerProps) {
+  const { t } = useTranslation('step2');
+
+  if (fit.overall !== 'warn' && fit.overall !== 'fail') return null;
+
+  const isFail = fit.overall === 'fail';
+  const fitTitle = isFail ? t('singleVmFit.titleFail') : t('singleVmFit.titleWarn');
+  const fitLines: string[] = [];
+  if (fit.vcpu === 'warn') {
+    fitLines.push(
+      t('singleVmFit.vcpuWarn', {
+        vcpu: fit.largestVmVcpus,
+        cores: fit.coresPerServer,
+        logical: fit.logicalCpus,
+      }),
+    );
+  } else if (fit.vcpu === 'fail') {
+    fitLines.push(
+      t('singleVmFit.vcpuFail', { vcpu: fit.largestVmVcpus, logical: fit.logicalCpus }),
+    );
+  }
+  if (fit.ram === 'warn') {
+    fitLines.push(
+      t('singleVmFit.ramWarn', {
+        ram: fit.largestVmRamGb,
+        usable: fit.usableRamGb,
+        nameplate: nameplateRamGb,
+      }),
+    );
+  } else if (fit.ram === 'fail') {
+    fitLines.push(t('singleVmFit.ramFail', { ram: fit.largestVmRamGb, nameplate: nameplateRamGb }));
+  }
+
+  return (
+    <div
+      className={
+        isFail
+          ? 'mt-3 flex flex-col gap-1 p-3 rounded border border-util-high/40 bg-util-high/10'
+          : 'mt-3 flex flex-col gap-1 p-3 rounded border border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20'
+      }
+      role={isFail ? 'alert' : 'status'}
+    >
+      <p
+        className={
+          isFail
+            ? 'text-sm font-medium text-util-high'
+            : 'text-sm font-medium text-amber-700 dark:text-amber-300'
+        }
+      >
+        {fitTitle}
+      </p>
+      {fitLines.map((line) => (
+        <p key={line} className="text-sm text-foreground/80">
+          {line}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/components/step2/__tests__/ScenarioResults.test.tsx
+++ b/src/components/step2/__tests__/ScenarioResults.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ScenarioResults — single-VM fit banner (non-blocking).
+ * amber when overall === 'warn', red when overall === 'fail', nothing for ok/unknown.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createDefaultScenario } from '@/lib/sizing/defaults';
+import { useClusterStore } from '@/store/useClusterStore';
+import { useScenariosStore } from '@/store/useScenariosStore';
+import { useWizardStore } from '@/store/useWizardStore';
+import { ScenarioResults } from '../ScenarioResults';
+
+// 2 sockets x 16 cores = 32 physical cores -> 64 logical CPUs, 512 GiB RAM/host.
+function fitScenario() {
+  return {
+    ...createDefaultScenario(),
+    socketsPerServer: 2,
+    coresPerSocket: 16,
+    ramPerServerGb: 512,
+  };
+}
+
+beforeEach(() => {
+  useScenariosStore.setState({ scenarios: [fitScenario()] });
+  useClusterStore.setState({ currentCluster: { totalVcpus: 0, totalPcores: 0, totalVms: 0 } });
+  useWizardStore.setState({ currentStep: 2, sizingMode: 'vcpu', layoutMode: 'hci' });
+});
+
+describe('ScenarioResults — single-VM fit banner', () => {
+  it('renders a FAIL banner when the largest VM cannot run on a single host', () => {
+    useClusterStore.setState({
+      currentCluster: { totalVcpus: 0, totalPcores: 0, totalVms: 0, largestVmVcpus: 999 },
+    });
+    const scenario = useScenariosStore.getState().scenarios[0]!;
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.getByText(/cannot run on a single host/i)).toBeInTheDocument();
+  });
+
+  it('renders a WARN banner when the largest VM relies on SMT / spans NUMA', () => {
+    useClusterStore.setState({
+      currentCluster: { totalVcpus: 0, totalPcores: 0, totalVms: 0, largestVmVcpus: 48 },
+    });
+    const scenario = useScenariosStore.getState().scenarios[0]!;
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.getByText(/rely on SMT/i)).toBeInTheDocument();
+  });
+
+  it('renders NO banner when the largest VM fits comfortably (ok)', () => {
+    useClusterStore.setState({
+      currentCluster: {
+        totalVcpus: 0,
+        totalPcores: 0,
+        totalVms: 0,
+        largestVmVcpus: 16,
+        largestVmRamGb: 128,
+      },
+    });
+    const scenario = useScenariosStore.getState().scenarios[0]!;
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.queryByText(/single host|rely on SMT/i)).toBeNull();
+  });
+
+  it('renders NO banner when there is no largest-VM data (unknown)', () => {
+    const scenario = useScenariosStore.getState().scenarios[0]!;
+    render(<ScenarioResults scenarioId={scenario.id} />);
+    expect(screen.queryByText(/single host|rely on SMT/i)).toBeNull();
+  });
+});

--- a/src/components/step3/__tests__/ComparisonTable.test.tsx
+++ b/src/components/step3/__tests__/ComparisonTable.test.tsx
@@ -17,6 +17,16 @@ vi.mock('@/hooks/useScenariosResults', () => ({
 }));
 
 import { useScenariosResults } from '@/hooks/useScenariosResults';
+import type { SingleVmFit } from '../../../lib/sizing/singleVmFit';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 const baseScenario = {
   id: 'a',
@@ -49,6 +59,7 @@ const baseResult = {
   cpuUtilizationPercent: 48.0,
   ramUtilizationPercent: 37.5,
   diskUtilizationPercent: 1.5,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 beforeEach(() => {

--- a/src/components/step3/__tests__/CoreCountChart.test.tsx
+++ b/src/components/step3/__tests__/CoreCountChart.test.tsx
@@ -17,6 +17,16 @@ vi.mock('@/hooks/useScenariosResults', () => ({
 }));
 
 import { useScenariosResults } from '@/hooks/useScenariosResults';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 const baseScenario = {
   id: 's1',
@@ -49,6 +59,7 @@ const baseResult = {
   cpuUtilizationPercent: 80,
   ramUtilizationPercent: 60,
   diskUtilizationPercent: 15,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 beforeEach(() => {

--- a/src/components/step3/__tests__/SizingChart.test.tsx
+++ b/src/components/step3/__tests__/SizingChart.test.tsx
@@ -18,6 +18,16 @@ vi.mock('@/hooks/useScenariosResults', () => ({
 }));
 
 import { useScenariosResults } from '@/hooks/useScenariosResults';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 const baseScenario = {
   id: 's1',
@@ -50,6 +60,7 @@ const baseResult = {
   cpuUtilizationPercent: 80,
   ramUtilizationPercent: 60,
   diskUtilizationPercent: 15,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 beforeEach(() => {

--- a/src/i18n/locales/de/step1.json
+++ b/src/i18n/locales/de/step1.json
@@ -67,6 +67,7 @@
     "title": "Import-Vorschau",
     "description": "Extrahierte Daten vor dem Ausfüllen des Formulars prüfen.",
     "filterByCluster": "Nach Cluster filtern",
+    "largestVm": "Größte VM: {{vcpu}} vCPU / {{ram}} GiB",
     "stretchDetected": "Stretched Cluster erkannt",
     "stretchSizingNote": "Die Dimensionierung verdoppelt die Serveranzahl für Standortsymmetrie.",
     "confirmStretchAriaLabel": "Stretched-Cluster-Topologie bestätigen",

--- a/src/i18n/locales/de/step2.json
+++ b/src/i18n/locales/de/step2.json
@@ -70,6 +70,14 @@
       "ghz": "GHz-begrenzt"
     }
   },
+  "singleVmFit": {
+    "titleWarn": "Größte VM passt nur knapp",
+    "titleFail": "Größte VM passt nicht auf einen Host",
+    "vcpuWarn": "Größte VM ({{vcpu}} vCPU) übersteigt die {{cores}} physischen Kerne dieses Hosts — sie würde auf SMT angewiesen sein / NUMA-Knoten überspannen ({{logical}} logische CPUs).",
+    "vcpuFail": "Größte VM ({{vcpu}} vCPU) übersteigt die {{logical}} logischen CPUs dieses Hosts — sie kann nicht auf einem einzelnen Host laufen.",
+    "ramWarn": "Größte VM benötigt {{ram}} GiB RAM; Host bietet {{usable}} GiB nutzbar (von {{nameplate}} GiB) — passt auf Nennkapazität, aber nicht nach Overhead.",
+    "ramFail": "Größte VM benötigt {{ram}} GiB RAM; Host bietet nur {{nameplate}} GiB — sie kann nicht auf einem einzelnen Host laufen."
+  },
   "vsan": {
     "heading": "vSAN-Einstellungen",
     "fttPolicy": "FTT-Richtlinie",

--- a/src/i18n/locales/en/step1.json
+++ b/src/i18n/locales/en/step1.json
@@ -67,6 +67,7 @@
     "title": "Import Preview",
     "description": "Review the extracted data before populating the form.",
     "filterByCluster": "Filter by cluster",
+    "largestVm": "Largest VM: {{vcpu}} vCPU / {{ram}} GiB",
     "stretchDetected": "Stretch cluster detected",
     "stretchSizingNote": "Sizing will double the server count for site symmetry.",
     "confirmStretchAriaLabel": "Confirm stretch cluster topology",

--- a/src/i18n/locales/en/step2.json
+++ b/src/i18n/locales/en/step2.json
@@ -70,6 +70,14 @@
       "ghz": "GHz-limited"
     }
   },
+  "singleVmFit": {
+    "titleWarn": "Largest VM is a tight fit",
+    "titleFail": "Largest VM does not fit one host",
+    "vcpuWarn": "Largest VM ({{vcpu}} vCPU) exceeds this host's {{cores}} physical cores — it would rely on SMT / span NUMA nodes ({{logical}} logical CPUs).",
+    "vcpuFail": "Largest VM ({{vcpu}} vCPU) exceeds this host's {{logical}} logical CPUs — it cannot run on a single host.",
+    "ramWarn": "Largest VM needs {{ram}} GiB RAM; host offers {{usable}} GiB usable (of {{nameplate}} GiB) — fits nameplate but not after overhead.",
+    "ramFail": "Largest VM needs {{ram}} GiB RAM; host offers only {{nameplate}} GiB — it cannot run on a single host."
+  },
   "vsan": {
     "heading": "vSAN Settings",
     "fttPolicy": "FTT Policy",

--- a/src/i18n/locales/fr/step1.json
+++ b/src/i18n/locales/fr/step1.json
@@ -67,6 +67,7 @@
     "title": "Aperçu de l'import",
     "description": "Vérifiez les données extraites avant de remplir le formulaire.",
     "filterByCluster": "Filtrer par cluster",
+    "largestVm": "Plus grande VM : {{vcpu}} vCPU / {{ram}} Gio",
     "stretchDetected": "Cluster étendu détecté",
     "stretchSizingNote": "Le dimensionnement doublera le nombre de serveurs pour la symétrie des sites.",
     "confirmStretchAriaLabel": "Confirmer la topologie de cluster étendu",

--- a/src/i18n/locales/fr/step2.json
+++ b/src/i18n/locales/fr/step2.json
@@ -70,6 +70,14 @@
       "ghz": "Limité GHz"
     }
   },
+  "singleVmFit": {
+    "titleWarn": "La plus grande VM tient tout juste",
+    "titleFail": "La plus grande VM ne tient pas sur un hôte",
+    "vcpuWarn": "La plus grande VM ({{vcpu}} vCPU) dépasse les {{cores}} cœurs physiques de cet hôte — elle reposerait sur le SMT / s'étendrait sur plusieurs nœuds NUMA ({{logical}} CPU logiques).",
+    "vcpuFail": "La plus grande VM ({{vcpu}} vCPU) dépasse les {{logical}} CPU logiques de cet hôte — elle ne peut pas tenir sur un seul hôte.",
+    "ramWarn": "La plus grande VM nécessite {{ram}} Gio de RAM ; l'hôte offre {{usable}} Gio utilisables (sur {{nameplate}} Gio) — tient sur la capacité nominale mais pas après surcharge.",
+    "ramFail": "La plus grande VM nécessite {{ram}} Gio de RAM ; l'hôte n'offre que {{nameplate}} Gio — elle ne peut pas tenir sur un seul hôte."
+  },
   "vsan": {
     "heading": "Paramètres vSAN",
     "fttPolicy": "Politique FTT",

--- a/src/i18n/locales/it/step1.json
+++ b/src/i18n/locales/it/step1.json
@@ -67,6 +67,7 @@
     "title": "Anteprima importazione",
     "description": "Verificare i dati estratti prima di popolare il modulo.",
     "filterByCluster": "Filtra per cluster",
+    "largestVm": "VM più grande: {{vcpu}} vCPU / {{ram}} GiB",
     "stretchDetected": "Cluster esteso rilevato",
     "stretchSizingNote": "Il dimensionamento raddoppierà il numero di server per la simmetria dei siti.",
     "confirmStretchAriaLabel": "Conferma topologia cluster esteso",

--- a/src/i18n/locales/it/step2.json
+++ b/src/i18n/locales/it/step2.json
@@ -70,6 +70,14 @@
       "ghz": "Limitato da GHz"
     }
   },
+  "singleVmFit": {
+    "titleWarn": "La VM più grande entra a malapena",
+    "titleFail": "La VM più grande non entra in un host",
+    "vcpuWarn": "La VM più grande ({{vcpu}} vCPU) supera i {{cores}} core fisici di questo host — si baserebbe su SMT / si estenderebbe su più nodi NUMA ({{logical}} CPU logiche).",
+    "vcpuFail": "La VM più grande ({{vcpu}} vCPU) supera le {{logical}} CPU logiche di questo host — non può funzionare su un singolo host.",
+    "ramWarn": "La VM più grande richiede {{ram}} GiB di RAM; l'host offre {{usable}} GiB utilizzabili (su {{nameplate}} GiB) — entra nella capacità nominale ma non dopo l'overhead.",
+    "ramFail": "La VM più grande richiede {{ram}} GiB di RAM; l'host offre solo {{nameplate}} GiB — non può funzionare su un singolo host."
+  },
   "vsan": {
     "heading": "Impostazioni vSAN",
     "fttPolicy": "Policy FTT",

--- a/src/lib/sizing/__tests__/constraints.test.ts
+++ b/src/lib/sizing/__tests__/constraints.test.ts
@@ -798,6 +798,21 @@ describe('computeScenarioResult — stretch cluster', () => {
   });
 });
 
+describe('computeScenarioResult — singleVmFit', () => {
+  it('includes a singleVmFit verdict on every result', () => {
+    const result = computeScenarioResult(CPU_LIMITED_CLUSTER, CPU_LIMITED_SCENARIO);
+    expect(result.singleVmFit).toBeDefined();
+    // CPU_LIMITED_CLUSTER has no largestVm* fields -> both dimensions unknown.
+    expect(result.singleVmFit.overall).toBe('unknown');
+  });
+
+  it('flags a monster VM that exceeds the host', () => {
+    const cluster = { ...CPU_LIMITED_CLUSTER, largestVmVcpus: 999, largestVmRamGb: 99999 };
+    const result = computeScenarioResult(cluster, CPU_LIMITED_SCENARIO);
+    expect(result.singleVmFit.overall).toBe('fail');
+  });
+});
+
 export {
   CPU_LIMITED_CLUSTER,
   CPU_LIMITED_SCENARIO,

--- a/src/lib/sizing/__tests__/singleVmFit.test.ts
+++ b/src/lib/sizing/__tests__/singleVmFit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { OldCluster, Scenario } from '../../../types/cluster';
+import { createDefaultScenario } from '../defaults';
+import { assessSingleVmFit, SMT_THREADS_PER_CORE } from '../singleVmFit';
+
+// Host: 2 x 16 = 32 cores, 64 logical (SMT 2), 512 GiB nameplate, no vSAN.
+const HOST: Scenario = {
+  ...createDefaultScenario(),
+  socketsPerServer: 2,
+  coresPerSocket: 16,
+  ramPerServerGb: 512,
+};
+
+function clusterWith(largestVmVcpus?: number, largestVmRamGb?: number): OldCluster {
+  return {
+    totalVcpus: 0,
+    totalPcores: 0,
+    totalVms: 0,
+    ...(largestVmVcpus !== undefined && { largestVmVcpus }),
+    ...(largestVmRamGb !== undefined && { largestVmRamGb }),
+  };
+}
+
+describe('SMT_THREADS_PER_CORE', () => {
+  it('is 2 (x86 standard)', () => {
+    expect(SMT_THREADS_PER_CORE).toBe(2);
+  });
+});
+
+describe('assessSingleVmFit — vCPU dimension', () => {
+  it('ok when largest vCPU <= physical cores', () => {
+    expect(assessSingleVmFit(clusterWith(32, 8), HOST).vcpu).toBe('ok');
+  });
+  it('warn when largest vCPU is between cores and logical CPUs (relies on SMT)', () => {
+    expect(assessSingleVmFit(clusterWith(48, 8), HOST).vcpu).toBe('warn');
+  });
+  it('fail when largest vCPU exceeds logical CPUs', () => {
+    expect(assessSingleVmFit(clusterWith(96, 8), HOST).vcpu).toBe('fail');
+  });
+  it('unknown when no largest-vCPU data', () => {
+    expect(assessSingleVmFit(clusterWith(undefined, 8), HOST).vcpu).toBe('unknown');
+  });
+});
+
+describe('assessSingleVmFit — RAM dimension', () => {
+  it('ok when largest RAM <= usable (no vSAN -> usable === nameplate)', () => {
+    expect(assessSingleVmFit(clusterWith(8, 512), HOST).ram).toBe('ok');
+  });
+  it('fail when largest RAM exceeds nameplate', () => {
+    expect(assessSingleVmFit(clusterWith(8, 768), HOST).ram).toBe('fail');
+  });
+  it('warn when largest RAM is between usable and nameplate (vSAN overhead)', () => {
+    const vsanHost: Scenario = { ...HOST, vsanFttPolicy: 'mirror-1', vsanMemoryPerHostGb: 6 };
+    expect(assessSingleVmFit(clusterWith(8, 510), vsanHost).ram).toBe('warn');
+    expect(assessSingleVmFit(clusterWith(8, 510), vsanHost).usableRamGb).toBe(506);
+  });
+  it('unknown when no largest-RAM data', () => {
+    expect(assessSingleVmFit(clusterWith(8, undefined), HOST).ram).toBe('unknown');
+  });
+});
+
+describe('assessSingleVmFit — overall', () => {
+  it('overall is the worst of the two known dimensions', () => {
+    expect(assessSingleVmFit(clusterWith(48, 768), HOST).overall).toBe('fail');
+  });
+  it('overall ignores an unknown dimension', () => {
+    expect(assessSingleVmFit(clusterWith(48, undefined), HOST).overall).toBe('warn');
+  });
+  it('overall is unknown when both dimensions are unknown', () => {
+    expect(assessSingleVmFit(clusterWith(undefined, undefined), HOST).overall).toBe('unknown');
+  });
+  it('echoes the host geometry and largest-VM numbers for UI copy', () => {
+    const fit = assessSingleVmFit(clusterWith(48, 256), HOST);
+    expect(fit.coresPerServer).toBe(32);
+    expect(fit.logicalCpus).toBe(64);
+    expect(fit.largestVmVcpus).toBe(48);
+    expect(fit.largestVmRamGb).toBe(256);
+  });
+});

--- a/src/lib/sizing/__tests__/singleVmFit.test.ts
+++ b/src/lib/sizing/__tests__/singleVmFit.test.ts
@@ -77,3 +77,28 @@ describe('assessSingleVmFit — overall', () => {
     expect(fit.largestVmRamGb).toBe(256);
   });
 });
+
+describe('assessSingleVmFit — degenerate host config (no division, only compares)', () => {
+  const ZERO_HOST: Scenario = {
+    ...createDefaultScenario(),
+    socketsPerServer: 0,
+    coresPerSocket: 0,
+    ramPerServerGb: 0,
+  };
+
+  it('fails a positive largest VM against a zero-core / zero-RAM host', () => {
+    const fit = assessSingleVmFit(clusterWith(8, 16), ZERO_HOST);
+    expect(fit.vcpu).toBe('fail');
+    expect(fit.ram).toBe('fail');
+    expect(fit.overall).toBe('fail');
+  });
+
+  it('treats a zero-sized largest VM as ok (0 <= 0), never NaN', () => {
+    const fit = assessSingleVmFit(clusterWith(0, 0), ZERO_HOST);
+    expect(fit.vcpu).toBe('ok');
+    expect(fit.ram).toBe('ok');
+    expect(fit.coresPerServer).toBe(0);
+    expect(fit.logicalCpus).toBe(0);
+    expect(fit.usableRamGb).toBe(0);
+  });
+});

--- a/src/lib/sizing/__tests__/vsanBreakdown.test.ts
+++ b/src/lib/sizing/__tests__/vsanBreakdown.test.ts
@@ -8,7 +8,17 @@ import { describe, expect, it } from 'vitest';
 import type { ResourceBreakdown, StorageBreakdown } from '../../../types/breakdown';
 import type { OldCluster, Scenario } from '../../../types/cluster';
 import type { ScenarioResult } from '../../../types/results';
+import type { SingleVmFit } from '../singleVmFit';
 import { computeVsanBreakdown } from '../vsanBreakdown';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 /** Helper to assert the CAP-06 invariant on a ResourceBreakdown */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -79,6 +89,7 @@ function makeResult(overrides: Partial<ScenarioResult> = {}): ScenarioResult {
     cpuUtilizationPercent: 50,
     ramUtilizationPercent: 50,
     diskUtilizationPercent: 12.5,
+    singleVmFit: UNKNOWN_SINGLE_VM_FIT,
     ...overrides,
   };
 }

--- a/src/lib/sizing/constraints.ts
+++ b/src/lib/sizing/constraints.ts
@@ -7,6 +7,7 @@ import {
   serverCountByRam,
   serverCountBySpecint,
 } from './formulas';
+import { assessSingleVmFit } from './singleVmFit';
 import { VSAN_DEFAULT_SLACK_PERCENT } from './vsanConstants';
 import {
   computeVsanEffectiveGhzPerNode,
@@ -254,6 +255,7 @@ export function computeScenarioResult(
     ramUtilizationPercent,
     diskUtilizationPercent,
     stretchApplied,
+    singleVmFit: assessSingleVmFit(cluster, scenario),
     ...(stretchPairedCount !== undefined && { stretchPairedCount }),
   });
 }

--- a/src/lib/sizing/singleVmFit.ts
+++ b/src/lib/sizing/singleVmFit.ts
@@ -1,0 +1,70 @@
+// All RAM values (largestVmRamGb, ramPerServerGb, usableRamGb) are compared as GiB.
+import type { OldCluster, Scenario } from '../../types/cluster';
+import { computeVsanEffectiveRamPerNode } from './vsanFormulas';
+
+export type FitVerdict = 'ok' | 'warn' | 'fail' | 'unknown';
+
+export interface SingleVmFit {
+  vcpu: FitVerdict;
+  ram: FitVerdict;
+  /** Worst of vcpu/ram; an `unknown` dimension is ignored unless both are unknown. */
+  overall: FitVerdict;
+  largestVmVcpus?: number; // echoed for UI copy
+  largestVmRamGb?: number;
+  coresPerServer: number; // sockets x cores/socket
+  logicalCpus: number; // coresPerServer x SMT_THREADS_PER_CORE
+  usableRamGb: number; // vSAN-aware
+}
+
+/** x86 standard 2 threads/core. YAGNI to make configurable now. */
+export const SMT_THREADS_PER_CORE = 2;
+
+const RANK: Record<FitVerdict, number> = { unknown: -1, ok: 0, warn: 1, fail: 2 };
+
+function assessVcpu(largest: number | undefined, cores: number, logical: number): FitVerdict {
+  if (largest === undefined) return 'unknown';
+  if (largest <= cores) return 'ok';
+  if (largest <= logical) return 'warn';
+  return 'fail';
+}
+
+function assessRam(largest: number | undefined, usable: number, nameplate: number): FitVerdict {
+  if (largest === undefined) return 'unknown';
+  if (largest <= usable) return 'ok';
+  if (largest <= nameplate) return 'warn';
+  return 'fail';
+}
+
+function worstVerdict(a: FitVerdict, b: FitVerdict): FitVerdict {
+  const known = [a, b].filter((v): v is Exclude<FitVerdict, 'unknown'> => v !== 'unknown');
+  if (known.length === 0) return 'unknown';
+  return known.reduce((worst, v) => (RANK[v] > RANK[worst] ? v : worst));
+}
+
+/**
+ * Non-blocking single-VM fit check: can the cluster's largest VM (by vCPU and by
+ * RAM, independently) fit on ONE proposed target host? Pure; never divides -- only
+ * compares -- so degenerate host configs (cores=0/RAM=0) compare cleanly.
+ */
+export function assessSingleVmFit(cluster: OldCluster, scenario: Scenario): SingleVmFit {
+  const coresPerServer = scenario.socketsPerServer * scenario.coresPerSocket;
+  const logicalCpus = coresPerServer * SMT_THREADS_PER_CORE;
+  const vsanApplies = scenario.vsanFttPolicy !== undefined;
+  const usableRamGb = vsanApplies
+    ? computeVsanEffectiveRamPerNode(scenario.ramPerServerGb, scenario.vsanMemoryPerHostGb)
+    : scenario.ramPerServerGb;
+
+  const vcpu = assessVcpu(cluster.largestVmVcpus, coresPerServer, logicalCpus);
+  const ram = assessRam(cluster.largestVmRamGb, usableRamGb, scenario.ramPerServerGb);
+
+  return {
+    vcpu,
+    ram,
+    overall: worstVerdict(vcpu, ram),
+    ...(cluster.largestVmVcpus !== undefined && { largestVmVcpus: cluster.largestVmVcpus }),
+    ...(cluster.largestVmRamGb !== undefined && { largestVmRamGb: cluster.largestVmRamGb }),
+    coresPerServer,
+    logicalCpus,
+    usableRamGb,
+  };
+}

--- a/src/lib/utils/__tests__/clipboard.test.ts
+++ b/src/lib/utils/__tests__/clipboard.test.ts
@@ -5,7 +5,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { OldCluster, Scenario } from '@/types/cluster';
 import type { ScenarioResult } from '@/types/results';
+import type { SingleVmFit } from '../../sizing/singleVmFit';
 import { buildSummaryText, copyToClipboard } from '../clipboard';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 const cluster: OldCluster = {
   totalVcpus: 2000,
@@ -45,6 +55,7 @@ const result: ScenarioResult = {
   cpuUtilizationPercent: 85.0,
   ramUtilizationPercent: 60.0,
   diskUtilizationPercent: 35.0,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 beforeEach(() => {

--- a/src/lib/utils/__tests__/export.test.ts
+++ b/src/lib/utils/__tests__/export.test.ts
@@ -3,10 +3,10 @@
  * Requirements: EXPO-02, EXPO-03
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
 import type { ResourceBreakdown, StorageBreakdown, VsanCapacityBreakdown } from '@/types/breakdown';
 import type { OldCluster, Scenario } from '@/types/cluster';
 import type { ScenarioResult } from '@/types/results';
-import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
 import { buildCsvContent, buildJsonContent, csvEscape, downloadCsv, downloadJson } from '../export';
 
 const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {

--- a/src/lib/utils/__tests__/export.test.ts
+++ b/src/lib/utils/__tests__/export.test.ts
@@ -6,7 +6,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResourceBreakdown, StorageBreakdown, VsanCapacityBreakdown } from '@/types/breakdown';
 import type { OldCluster, Scenario } from '@/types/cluster';
 import type { ScenarioResult } from '@/types/results';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
 import { buildCsvContent, buildJsonContent, csvEscape, downloadCsv, downloadJson } from '../export';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 const cluster: OldCluster = {
   totalVcpus: 2000,
@@ -45,6 +55,7 @@ const result: ScenarioResult = {
   ramUtilizationPercent: 60.0,
   diskUtilizationPercent: 35.0,
   stretchApplied: false,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 const resourceBd: ResourceBreakdown = {

--- a/src/lib/utils/__tests__/exportPptx.test.ts
+++ b/src/lib/utils/__tests__/exportPptx.test.ts
@@ -6,10 +6,10 @@
  * Visual assertions target the Midnight Executive palette + Arial/Consolas fonts.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
 import type { ResourceBreakdown, StorageBreakdown, VsanCapacityBreakdown } from '@/types/breakdown';
 import type { OldCluster, Scenario } from '@/types/cluster';
 import type { ScenarioResult } from '@/types/results';
-import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
 
 const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
   vcpu: 'unknown',

--- a/src/lib/utils/__tests__/exportPptx.test.ts
+++ b/src/lib/utils/__tests__/exportPptx.test.ts
@@ -9,6 +9,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResourceBreakdown, StorageBreakdown, VsanCapacityBreakdown } from '@/types/breakdown';
 import type { OldCluster, Scenario } from '@/types/cluster';
 import type { ScenarioResult } from '@/types/results';
+import type { SingleVmFit } from '@/lib/sizing/singleVmFit';
+
+const UNKNOWN_SINGLE_VM_FIT: SingleVmFit = {
+  vcpu: 'unknown',
+  ram: 'unknown',
+  overall: 'unknown',
+  coresPerServer: 0,
+  logicalCpus: 0,
+  usableRamGb: 0,
+};
 
 // ---------------------------------------------------------------------------
 // Mock pptxgenjs
@@ -85,6 +95,7 @@ const result: ScenarioResult = {
   cpuUtilizationPercent: 74.4,
   ramUtilizationPercent: 67.2,
   diskUtilizationPercent: 10.7,
+  singleVmFit: UNKNOWN_SINGLE_VM_FIT,
 };
 
 const resourceBd: ResourceBreakdown = {

--- a/src/lib/utils/import/__tests__/liveopticParser.test.ts
+++ b/src/lib/utils/import/__tests__/liveopticParser.test.ts
@@ -211,6 +211,33 @@ describe('liveopticParser', () => {
       expect(result.rawByScope?.get('CL-B')?.totalVcpus).toBe(8);
     });
 
+    it('captures per-scope largest VM by vCPU and by RAM (independent dimensions)', async () => {
+      vi.mocked(XLSX.utils.sheet_to_json).mockReturnValue([
+        // RAM-max VM (low vCPU, high RAM)
+        {
+          'VM Name': 'mem-hog',
+          'Virtual CPU': 4,
+          'Provisioned Memory (MiB)': 65536,
+          'Virtual Disk Size (MiB)': 102400,
+          Template: false,
+          Cluster: 'CL-A',
+        },
+        // vCPU-max VM (high vCPU, low RAM) — a DIFFERENT VM
+        {
+          'VM Name': 'cpu-hog',
+          'Virtual CPU': 32,
+          'Provisioned Memory (MiB)': 8192,
+          'Virtual Disk Size (MiB)': 204800,
+          Template: false,
+          Cluster: 'CL-A',
+        },
+      ]);
+      const result = await parseLiveoptics(new ArrayBuffer(0), 'liveoptics-xlsx');
+      const scope = result.rawByScope?.get('CL-A');
+      expect(scope?.largestVmVcpus).toBe(32);
+      expect(scope?.largestVmRamMib).toBe(65536);
+    });
+
     it("file with no cluster column defaults to '__all__'", async () => {
       vi.mocked(XLSX.utils.sheet_to_json).mockReturnValue([
         {

--- a/src/lib/utils/import/__tests__/rvtoolsParser.test.ts
+++ b/src/lib/utils/import/__tests__/rvtoolsParser.test.ts
@@ -179,6 +179,33 @@ describe('rvtoolsParser', () => {
       expect(result.detectedScopes).toContain('CL-B');
     });
 
+    it('captures per-scope largest VM by vCPU and by RAM (independent dimensions)', async () => {
+      vi.mocked(XLSX.utils.sheet_to_json).mockReturnValue([
+        // RAM-max VM (low vCPU, high RAM)
+        {
+          VM: 'mem-hog',
+          CPUs: 4,
+          Memory: 65536,
+          'Provisioned MB': 102400,
+          Template: false,
+          Cluster: 'CL-A',
+        },
+        // vCPU-max VM (high vCPU, low RAM) — a DIFFERENT VM
+        {
+          VM: 'cpu-hog',
+          CPUs: 32,
+          Memory: 8192,
+          'Provisioned MB': 204800,
+          Template: false,
+          Cluster: 'CL-A',
+        },
+      ]);
+      const result = await parseRvtools(new ArrayBuffer(0));
+      const scope = result.rawByScope?.get('CL-A');
+      expect(scope?.largestVmVcpus).toBe(32);
+      expect(scope?.largestVmRamMib).toBe(65536);
+    });
+
     it('rawByScope contains independent vcpu totals per cluster', async () => {
       vi.mocked(XLSX.utils.sheet_to_json).mockReturnValue([
         {

--- a/src/lib/utils/import/__tests__/scopeAggregator.test.ts
+++ b/src/lib/utils/import/__tests__/scopeAggregator.test.ts
@@ -284,4 +284,64 @@ describe('aggregateScopes', () => {
     const result = aggregateScopes(map, ['CL-A', 'CL-B']);
     expect(result.isStretchCluster).toBeUndefined();
   });
+
+  it('takes the MAX largest-VM vCPU and RAM across selected scopes (not the sum)', () => {
+    const map = new Map<string, ScopeEntry>([
+      [
+        'A',
+        makeScope({
+          totalVcpus: 10,
+          totalVms: 5,
+          avgRamPerVmGb: 4,
+          vmCount: 5,
+          largestVmVcpus: 16,
+          largestVmRamMib: 32768,
+        }),
+      ],
+      [
+        'B',
+        makeScope({
+          totalVcpus: 10,
+          totalVms: 5,
+          avgRamPerVmGb: 4,
+          vmCount: 5,
+          largestVmVcpus: 48,
+          largestVmRamMib: 16384,
+        }),
+      ],
+    ]);
+    const agg = aggregateScopes(map, ['A', 'B']);
+    expect(agg.largestVmVcpus).toBe(48); // max, not 64
+    expect(agg.largestVmRamMib).toBe(32768); // max, not 49152
+  });
+
+  it('omits largest-VM fields when no selected scope has them', () => {
+    const map = new Map<string, ScopeEntry>([
+      ['A', makeScope({ totalVcpus: 10, totalVms: 5, avgRamPerVmGb: 4, vmCount: 5 })],
+    ]);
+    const agg = aggregateScopes(map, ['A']);
+    expect(agg.largestVmVcpus).toBeUndefined();
+    expect(agg.largestVmRamMib).toBeUndefined();
+  });
+
+  it('uses the largest-VM values from the only scope that has them (mixed presence)', () => {
+    const map = new Map<string, ScopeEntry>([
+      ['A', makeScope({ totalVcpus: 10, totalVms: 5, avgRamPerVmGb: 4, vmCount: 5 })],
+      [
+        'B',
+        makeScope({
+          totalVcpus: 10,
+          totalVms: 5,
+          avgRamPerVmGb: 4,
+          vmCount: 5,
+          largestVmVcpus: 24,
+          largestVmRamMib: 8192,
+        }),
+      ],
+    ]);
+    const agg = aggregateScopes(map, ['A', 'B']);
+    // Scope A lacks the fields and must be skipped (not treated as 0-and-winning).
+    expect(agg.largestVmVcpus).toBe(24);
+    expect(agg.largestVmRamMib).toBe(8192);
+  });
 });

--- a/src/lib/utils/import/index.ts
+++ b/src/lib/utils/import/index.ts
@@ -32,6 +32,10 @@ export interface ClusterImportResult {
   ramUtilizationPercent?: number;
   cpuFrequencyGhz?: number; // avg CPU clock frequency in GHz (from vHost / ESX Hosts)
   cpuModel?: string; // display-only CPU model string from first host
+  /** Largest single VM by vCPU count across this scope's VM rows (import only). */
+  largestVmVcpus?: number;
+  /** Largest single VM by RAM in MiB across this scope's VM rows (import only). */
+  largestVmRamMib?: number;
   // Topology detection (Phase: stretch cluster)
   isStretchCluster?: boolean; // detected stretched-cluster topology (vSAN sheet or heuristics)
   stretchSignals?: string[]; // human-readable reasons feeding the preview tooltip

--- a/src/lib/utils/import/jsonParser.ts
+++ b/src/lib/utils/import/jsonParser.ts
@@ -60,6 +60,8 @@ export function parsePresizionJson(buffer: ArrayBuffer): JsonImportResult {
       ramUtilizationPercent: num(c.ramUtilizationPercent, 'ramUtilizationPercent'),
     }),
     ...(typeof c.isStretchCluster === 'boolean' && { isStretchCluster: c.isStretchCluster }),
+    ...(c.largestVmVcpus != null && { largestVmVcpus: num(c.largestVmVcpus, 'largestVmVcpus') }),
+    ...(c.largestVmRamGb != null && { largestVmRamGb: num(c.largestVmRamGb, 'largestVmRamGb') }),
   };
 
   if (!Array.isArray(scenarios)) {

--- a/src/lib/utils/import/liveopticParser.ts
+++ b/src/lib/utils/import/liveopticParser.ts
@@ -28,6 +28,8 @@ interface ScopeAccum {
   totalMemMib: number;
   totalDiskMib: number;
   vmCount: number;
+  largestVcpus: number;
+  largestMemMib: number;
 }
 
 /** Host aliases used to resolve ESX Host column on VMs sheet */
@@ -338,12 +340,16 @@ function aggregate(rows: VmRow[]): AggregateOutput {
       totalMemMib: 0,
       totalDiskMib: 0,
       vmCount: 0,
+      largestVcpus: 0,
+      largestMemMib: 0,
     };
     scopeMap.set(scopeKey, {
       totalVcpus: existing.totalVcpus + cpus,
       totalMemMib: existing.totalMemMib + mem,
       totalDiskMib: existing.totalDiskMib + disk,
       vmCount: existing.vmCount + 1,
+      largestVcpus: Math.max(existing.largestVcpus, cpus),
+      largestMemMib: Math.max(existing.largestMemMib, mem),
     });
   }
 
@@ -363,6 +369,8 @@ function aggregate(rows: VmRow[]): AggregateOutput {
         accum.vmCount > 0 ? Math.round((accum.totalMemMib / accum.vmCount / 1024) * 10) / 10 : 0,
       vmCount: accum.vmCount,
       warnings: [],
+      largestVmVcpus: accum.largestVcpus,
+      largestVmRamMib: accum.largestMemMib,
     });
   }
 

--- a/src/lib/utils/import/rvtoolsParser.ts
+++ b/src/lib/utils/import/rvtoolsParser.ts
@@ -32,6 +32,8 @@ interface ScopeAccum {
   totalMemMib: number;
   totalDiskMib: number;
   vmCount: number;
+  largestVcpus: number;
+  largestMemMib: number;
 }
 
 /** Compute ESX fields for a group of vHost rows */
@@ -146,12 +148,16 @@ export async function parseRvtools(
       totalMemMib: 0,
       totalDiskMib: 0,
       vmCount: 0,
+      largestVcpus: 0,
+      largestMemMib: 0,
     };
     scopeMap.set(scopeKey, {
       totalVcpus: existing.totalVcpus + cpus,
       totalMemMib: existing.totalMemMib + mem,
       totalDiskMib: existing.totalDiskMib + disk,
       vmCount: existing.vmCount + 1,
+      largestVcpus: Math.max(existing.largestVcpus, cpus),
+      largestMemMib: Math.max(existing.largestMemMib, mem),
     });
   }
 
@@ -171,6 +177,8 @@ export async function parseRvtools(
         accum.vmCount > 0 ? Math.round((accum.totalMemMib / accum.vmCount / 1024) * 10) / 10 : 0,
       vmCount: accum.vmCount,
       warnings: [],
+      largestVmVcpus: accum.largestVcpus,
+      largestVmRamMib: accum.largestMemMib,
     });
   }
 

--- a/src/lib/utils/import/scopeAggregator.ts
+++ b/src/lib/utils/import/scopeAggregator.ts
@@ -11,6 +11,7 @@ type RawByScopeMap = Map<string, ScopeData>;
  * - Representative: socketsPerServer, coresPerSocket, cpuModel, cpuFrequencyGhz (first scope)
  * - Weighted average by host count: ramPerServerGb (warns if heterogeneous)
  * - Weighted average by server count: cpuUtilizationPercent, ramUtilizationPercent
+ * - Max across scopes: largestVmVcpus, largestVmRamMib (a VM lives in exactly one scope)
  */
 export function aggregateScopes(rawByScope: RawByScopeMap, selectedKeys: string[]): ScopeData {
   if (selectedKeys.length === 0) {
@@ -67,6 +68,10 @@ export function aggregateScopes(rawByScope: RawByScopeMap, selectedKeys: string[
   let cpuUtilServerCount = 0;
   let ramUtilServerCount = 0;
 
+  // Largest-VM fields: MAX across scopes (a single VM lives in exactly one scope).
+  let maxLargestVmVcpus: number | undefined;
+  let maxLargestVmRamMib: number | undefined;
+
   // Stretch: any selected scope being stretched poisons the aggregate (conservative).
   let anyStretch = false;
   const stretchSignalsAcc: string[] = [];
@@ -121,6 +126,13 @@ export function aggregateScopes(rawByScope: RawByScopeMap, selectedKeys: string[
       ramUtilServerCount += scope.existingServerCount;
     }
 
+    if (scope.largestVmVcpus !== undefined) {
+      maxLargestVmVcpus = Math.max(maxLargestVmVcpus ?? 0, scope.largestVmVcpus);
+    }
+    if (scope.largestVmRamMib !== undefined) {
+      maxLargestVmRamMib = Math.max(maxLargestVmRamMib ?? 0, scope.largestVmRamMib);
+    }
+
     if (scope.isStretchCluster === true) {
       anyStretch = true;
       if (scope.stretchSignals) {
@@ -156,6 +168,10 @@ export function aggregateScopes(rawByScope: RawByScopeMap, selectedKeys: string[
       );
     }
   }
+
+  // Largest-VM fields: max across scopes
+  if (maxLargestVmVcpus !== undefined) esxFields.largestVmVcpus = maxLargestVmVcpus;
+  if (maxLargestVmRamMib !== undefined) esxFields.largestVmRamMib = maxLargestVmRamMib;
 
   // Weighted average utilization
   if (cpuUtilServerCount > 0) {

--- a/src/schemas/__tests__/schemas.test.ts
+++ b/src/schemas/__tests__/schemas.test.ts
@@ -66,6 +66,18 @@ describe('currentClusterSchema', () => {
       currentClusterSchema.parse({ totalVcpus: -1, totalPcores: 50, totalVms: 20 }),
     ).toThrow();
   });
+
+  it('parses and preserves largestVmVcpus and largestVmRamGb', () => {
+    const result = currentClusterSchema.parse({
+      totalVcpus: 100,
+      totalPcores: 50,
+      totalVms: 20,
+      largestVmVcpus: 48,
+      largestVmRamGb: 512,
+    });
+    expect(result.largestVmVcpus).toBe(48);
+    expect(result.largestVmRamGb).toBe(512);
+  });
 });
 
 // Valid RFC 4122 v4 UUID for test fixtures

--- a/src/schemas/currentClusterSchema.ts
+++ b/src/schemas/currentClusterSchema.ts
@@ -64,6 +64,8 @@ export const currentClusterSchema = z.object({
   ramUtilizationPercent: optionalPercent,
   cpuFrequencyGhz: optionalPositiveNumber,
   isStretchCluster: z.boolean().optional(),
+  largestVmVcpus: optionalNonNegativeNumber,
+  largestVmRamGb: optionalNonNegativeNumber,
 });
 
 export type CurrentClusterInput = z.infer<typeof currentClusterSchema>;

--- a/src/types/cluster.ts
+++ b/src/types/cluster.ts
@@ -20,6 +20,8 @@ export interface OldCluster {
   readonly cpuFrequencyGhz?: number; // avg CPU clock frequency in GHz — required for GHz sizing mode
   readonly cpuModel?: string; // display-only CPU model string extracted from import (e.g. "Xeon Gold 6526Y")
   readonly isStretchCluster?: boolean; // stretched topology — each site must carry the full workload on failure
+  readonly largestVmVcpus?: number; // largest single VM by vCPU (import only) — single-VM fit check
+  readonly largestVmRamGb?: number; // largest single VM by RAM in GiB (import only) — single-VM fit check
 }
 
 /**

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -2,6 +2,8 @@
  * The resource type that drove the final server count.
  * Whichever constraint produces the highest server count is the limiting resource.
  */
+import type { SingleVmFit } from '../lib/sizing/singleVmFit';
+
 export type LimitingResource = 'cpu' | 'ram' | 'disk' | 'specint' | 'ghz';
 
 /**
@@ -35,4 +37,6 @@ export interface ScenarioResult {
   readonly stretchApplied: boolean;
   /** Server count after stretch doubling + even-rounding, before HA reserve. Undefined when not applied. */
   readonly stretchPairedCount?: number;
+  /** Non-blocking single-VM feasibility verdict (largest VM vs one host). */
+  readonly singleVmFit: SingleVmFit;
 }


### PR DESCRIPTION
## Summary

Adds a **non-blocking, two-tier feasibility check** that warns when a refreshed cluster's **largest single VM** — by vCPU or by RAM, independently — cannot fit on **one** proposed target host. Previously the app sized purely from aggregates and could silently recommend a host smaller than a monster VM needs (e.g. a 384 GiB host for a 512 GiB VM, or fewer logical CPUs than a VM's vCPU count).

- **Capture** the largest VM (by vCPU and by RAM) at import only (RVTools/LiveOptics per-VM rows); manual entry has no per-VM data → verdict `unknown` → check silently skipped.
- **Assess** fit in a pure helper `src/lib/sizing/singleVmFit.ts` (vCPU vs cores/logical-with-SMT; RAM vs vSAN-aware usable/nameplate). Two tiers: amber `warn`, red `fail` — **never blocks** advancing or export.
- **Surface** a per-scenario banner in Step 2 (`SingleVmFitBanner`) and a largest-VM info line in the Step 1 import preview. All copy is i18n-driven (en/fr/de/it).

The largest-vCPU VM and largest-RAM VM may be different VMs — that's correct: the two host dimensions are independent, so the worst case per dimension is what must fit. The vCPU:pCore ratio is an aggregate consolidation cap and is deliberately **not** used for single-VM fit.

Spec: `docs/superpowers/specs/2026-06-01-biggest-vm-feasibility-design.md`
Plan: `docs/superpowers/plans/2026-06-01-biggest-vm-feasibility.md`

## Changes

| Area | Change |
|------|--------|
| Import parsers | Capture `largestVmVcpus` / `largestVmRamMib` (MiB) per scope |
| Aggregator | Combine scopes by **max** (a VM lives in one scope) |
| Model | `OldCluster.largestVmVcpus?` / `largestVmRamGb?` (GiB); MiB→GiB at one boundary; round-trips via Zod schema + JSON |
| Sizing | Pure `assessSingleVmFit(cluster, scenario)` → `SingleVmFit` embedded in every `ScenarioResult` |
| UI | Step 2 amber/red non-blocking banner; Step 1 import-preview info line |
| i18n | `step2.singleVmFit.*` + `step1.importPreview.largestVm` in 4 locales, parity-tested |

## Data flow integrity

RAM is MiB only at the parser/`ScopeData` layer; converted to GiB at exactly one boundary (`ImportPreviewModal.handleApply`) and for display (Step 1 line). The helper and banner only ever see GiB.

## Out of scope (per spec)

Configurable SMT threads/core, per-NUMA-node fit, Step 3 / PPTX surfacing, manual-entry largest-VM capture.

## Verification

- `tsc -b` clean
- `biome check .` — 0 errors
- `vitest run` — **829 passed** (75 files), incl. new tests for the helper (all tiers, vSAN path, both-unknown, degenerate host), parser/aggregator capture, schema round-trip, result integration, and both UI touch-points
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Largest VM Fit" checker to display whether the largest single VM can fit on proposed hosts within sizing scenarios. Non-blocking warnings and failure indicators now appear in Step 2 results, with additional largest VM capacity data displayed in Step 1 import preview.

* **Documentation**
  * Added implementation plan and design specification for the Largest VM Feasibility Check feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->