### PR TITLE
ci: adopt central web-release.yml@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  id-token: write       # OIDC for build-provenance attestation
+  attestations: write   # write the provenance attestation
 jobs:
   release:
     uses: fjacquet/ci/.github/workflows/web-release.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: fjacquet/ci/.github/workflows/web-release.yml@v1
+    with:
+      node-version: "24"
+      publish-npm: false
+      publish-docker: false
+      build-dir: "dist"


### PR DESCRIPTION
Adds a central, reusable release workflow to the repo.

- Triggered on `v*` tags
- Uses `fjacquet/ci/.github/workflows/web-release.yml@v1`
- node-version 24, build-dir `dist`
- npm publish and docker publish disabled
- Produces dist archives + SBOM

`actionlint` passes (exit 0). Required scripts (`typecheck`, `lint`, `test:run`, `build`) are all present in `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)